### PR TITLE
Feat/#9 book detail page

### DIFF
--- a/src/pages/book/detail.tsx
+++ b/src/pages/book/detail.tsx
@@ -1,7 +1,52 @@
 import React from 'react';
 
 const DetailPage = () => {
-  return <div>디테일페이지</div>;
+  return (
+    <div className='h-screen p-5'>
+      <div className='h-full flex flex-col gap-5'>
+        <div className='min-h-[10rem] flex'>
+          <div className='w-[30%] border-basic'>이미지</div>
+          <div className='w-[70%] flex flex-col pl-1'>
+            <div className='flex justify-between mb-2'>
+              <div className='flex'>
+                <h1 className='border-basic'>책명</h1>
+                <div className='border-basic'>저자</div>
+              </div>
+              <button className='border-basic'>책장에 담기</button>
+            </div>
+            <div className='h-full text-xs border-basic'>
+              책내용 사이즈보고 ... 잘라내기 책내용 사이즈보고 ... 잘라내기
+              책내용 사이즈보고 ... 잘라내기 책내용 사이즈보고 ... 잘라내기
+              책내용 사이즈보고 ... 잘라내기
+            </div>
+          </div>
+        </div>
+        <div className='border-basic flex justify-end'>
+          <button className='border-basic'>독서기록</button>
+        </div>
+        <div className='border-basic'>
+          <div>태그들</div>
+        </div>
+        <div className='grid grid-cols-3 4 gap-1 overflow-scroll'>
+          <div className='min-h-[8rem] border-basic'>1</div>
+          <div className='min-h-[8rem] border-basic'>1</div>
+          <div className='min-h-[8rem] border-basic'>1</div>
+          <div className='min-h-[8rem] border-basic'>1</div>
+          <div className='min-h-[8rem] border-basic'>1</div>
+          <div className='min-h-[8rem] border-basic'>1</div>
+          <div className='min-h-[8rem] border-basic'>1</div>
+          <div className='min-h-[8rem] border-basic'>1</div>
+          <div className='min-h-[8rem] border-basic'>1</div>
+          <div className='min-h-[8rem] border-basic'>1</div>
+          <div className='min-h-[8rem] border-basic'>1</div>
+          <div className='min-h-[8rem] border-basic'>1</div>
+          <div className='min-h-[8rem] border-basic'>1</div>
+          <div className='min-h-[8rem] border-basic'>1</div>
+          <div className='min-h-[8rem] border-basic'>1</div>
+        </div>
+      </div>
+    </div>
+  );
 };
 
 export default DetailPage;

--- a/src/pages/book/detail.tsx
+++ b/src/pages/book/detail.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const DetailPage = () => {
+  return <div>디테일페이지</div>;
+};
+
+export default DetailPage;

--- a/src/pages/book/detail/index.tsx
+++ b/src/pages/book/detail/index.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
-const DetailPage = () => {
+const BookDetailPage = () => {
   return (
-    <div className='h-screen p-5'>
+    <div className='h-screen p-5 border-2 border-red-500'>
       <div className='h-full flex flex-col gap-5'>
         <div className='min-h-[10rem] flex'>
           <div className='w-[30%] border-basic'>이미지</div>
@@ -49,4 +49,4 @@ const DetailPage = () => {
   );
 };
 
-export default DetailPage;
+export default BookDetailPage;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,3 +1,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+.border-basic {
+  @apply border-2 border-black;
+}


### PR DESCRIPTION
## 📌 이슈 번호

- close #9 

## 👩‍💻 작업 내용

- 도서 상세 페이지 라우트 지정
- 도서 상세 페이지 레이아웃 설정

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

<!-- 참고할 사항이 있다면 적어주세요 -->
![image](https://user-images.githubusercontent.com/91203029/235109397-54592196-df5b-464c-bbba-4049ffdb07b0.png)

1. 일단 저 스크린과 컨텐츠 사이 간격(빨간 border와 메인 컨텐츠 사이 간격)을 임의로 p-5(1.25rem)로 줬습니다.
2. globals.css에 기본으로 사용할 수 있도록 border-basic 만들어놓았습니다.
3. 저 태그 들어가는 부분 어떻게 해야할지 정해야할 것 같습니다. 이건 전체 회의에서 정해야할 듯?
4. 일단 데스크탑은 고려안하고 iPhone 12 Pro 기준으로 만들었습니다.
5. css가 세상에서 제일 어려운 것 같아요
