### PR TITLE
feat: 피드 이미지, 그 외 이미지 공통 컴포넌트 구현

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,6 +8,7 @@
   "plugins": ["simple-import-sort"],
   "rules": {
     "simple-import-sort/imports": "warn",
-    "simple-import-sort/exports": "warn"
+    "simple-import-sort/exports": "warn",
+    "@next/next/no-img-element": "off"
   }
 }

--- a/src/components/common/BookImage.tsx
+++ b/src/components/common/BookImage.tsx
@@ -17,19 +17,23 @@ interface Props {
   threshold: number;
   placeholder: string;
   src: string;
-  type: number;
+  feed?: string;
   alt: string;
-  onFeedImageClick: React.MouseEventHandler<HTMLDivElement>;
+  onImageClick?: React.MouseEventHandler<HTMLDivElement>;
 }
 
-const FeedImage = ({
+interface imageSizeType {
+  [key: string]: string;
+}
+
+const BookImage = ({
   lazy,
   threshold,
   placeholder,
   src,
-  type,
+  feed,
   alt,
-  onFeedImageClick,
+  onImageClick,
 }: Props) => {
   const [loaded, setLoaded] = useState(false);
   const imgRef = useRef<HTMLImageElement>(null);
@@ -60,12 +64,19 @@ const FeedImage = ({
     imgRef.current && observer.observe(imgRef.current);
   }, [lazy, threshold]);
 
+  const imageSize: imageSizeType = {
+    'type-1': 'w-[100%] pb-[100%] overflow-hidden',
+    'type-2': 'w-[50%] pb-[50%] overflow-hidden',
+    'type-3': 'w-[33%] pb-[33%] overflow-hidden',
+    'not-feed': `w-[90px] pb-[120px]`,
+  };
+
   return (
     <div
-      onClick={onFeedImageClick}
-      className={`${`w-[${Math.round(100 / type)}%] pb-[${Math.round(
-        100 / type,
-      )}%]`} h-0 relative overflow-hidden`}
+      onClick={feed ? onImageClick : undefined}
+      className={`${
+        feed ? imageSize[feed] : imageSize['not-feed']
+      } h-0 relative`}
     >
       <img
         className='absolute t-0 l-0 w-[100%] h-[100%]'
@@ -77,4 +88,4 @@ const FeedImage = ({
   );
 };
 
-export default FeedImage;
+export default BookImage;

--- a/src/components/common/BookImage.tsx
+++ b/src/components/common/BookImage.tsx
@@ -22,10 +22,6 @@ interface Props {
   onFeedImageClick: React.MouseEventHandler<HTMLDivElement>;
 }
 
-interface imageSizeType {
-  [key: number]: string;
-}
-
 const FeedImage = ({
   lazy,
   threshold,

--- a/src/components/common/BookImage.tsx
+++ b/src/components/common/BookImage.tsx
@@ -14,7 +14,7 @@ const onIntersection: IntersectionObserverCallback = (entries, io) => {
 
 interface Props {
   lazy: boolean;
-  threshold: number;
+  threshold?: number;
   placeholder: string;
   src: string;
   feed?: string;
@@ -28,7 +28,7 @@ interface imageSizeType {
 
 const BookImage = ({
   lazy,
-  threshold,
+  threshold = 0.5,
   placeholder,
   src,
   feed,

--- a/src/components/common/FeedImage.tsx
+++ b/src/components/common/FeedImage.tsx
@@ -38,12 +38,6 @@ const FeedImage = ({
   const [loaded, setLoaded] = useState(false);
   const imgRef = useRef<HTMLImageElement>(null);
 
-  const imageSize: imageSizeType = {
-    1: 'w-[100%] pb-[100%]',
-    2: 'w-[50%] pb-[50%]',
-    3: 'w-[33%] pb-[33%]',
-  };
-
   useEffect(() => {
     if (!lazy) {
       setLoaded(true);
@@ -73,7 +67,9 @@ const FeedImage = ({
   return (
     <div
       onClick={onFeedImageClick}
-      className={`${imageSize[type]} h-0 relative overflow-hidden`}
+      className={`${`w-[${Math.round(100 / type)}%] pb-[${Math.round(
+        100 / type,
+      )}%]`} h-0 relative overflow-hidden`}
     >
       <img
         className='absolute t-0 l-0 w-[100%] h-[100%]'

--- a/src/components/common/FeedImage.tsx
+++ b/src/components/common/FeedImage.tsx
@@ -1,0 +1,26 @@
+interface Props {
+  src: string;
+  type: number;
+  alt: string;
+  onFeedImageClick: React.MouseEventHandler<HTMLDivElement>;
+}
+
+interface imageSizeType {
+  [key: number]: string;
+}
+
+const FeedImage = ({ src, type, alt, onFeedImageClick }: Props) => {
+  const imageSize: imageSizeType = {
+    1: 'w-[100%] h-[100%]',
+    2: 'w-[50%] h-[50%]',
+    3: 'w-[33%] h-[33%]',
+  };
+
+  return (
+    <div onClick={onFeedImageClick}>
+      <img className={imageSize[type]} src={src} alt={alt} />
+    </div>
+  );
+};
+
+export default FeedImage;

--- a/src/components/common/FeedImage.tsx
+++ b/src/components/common/FeedImage.tsx
@@ -39,9 +39,9 @@ const FeedImage = ({
   const imgRef = useRef<HTMLImageElement>(null);
 
   const imageSize: imageSizeType = {
-    1: 'w-[100%] h-[100%]',
-    2: 'w-[50%] h-[50%]',
-    3: 'w-[33%] h-[33%]',
+    1: 'w-[100%] pb-[100%]',
+    2: 'w-[50%] pb-[50%]',
+    3: 'w-[33%] pb-[33%]',
   };
 
   useEffect(() => {
@@ -71,10 +71,13 @@ const FeedImage = ({
   }, [lazy, threshold]);
 
   return (
-    <div onClick={onFeedImageClick}>
+    <div
+      onClick={onFeedImageClick}
+      className={`${imageSize[type]} h-0 relative overflow-hidden`}
+    >
       <img
+        className='absolute t-0 l-0 w-[100%] h-[100%]'
         ref={imgRef}
-        className={imageSize[type]}
         src={loaded ? src : placeholder}
         alt={alt}
       />


### PR DESCRIPTION
## 📌 이슈 번호

- close #11 

## 👩‍💻 작업 내용
- 첫번째 사진은 피드를 제외한 곳에서 사용되는 이미지로 props를 값을 통해 데이터 바인딩을 하려 했는데 실패해서 width: 90px, height: 120px;를 설정함으로써 임시로 비율을 맞춰 두었습니다.
- 두번째 부터 네번째 사진은 피드에서 사용되는 이미지로 하나의 row에 배치할 수 있는 이미지의 개수가 다를 수도 있다고 생각해서 3종 류의 width 값(33%, 50%, 100%)을 통해 가로,세로 비율 1대1로 설정해두었습니다.

![20230430_181116](https://user-images.githubusercontent.com/60873508/235345226-fabd7c62-ac88-48ef-84a1-20e4e7c68236.png)



## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

<!-- 참고할 사항이 있다면 적어주세요 -->
