### PR TITLE
feat: 책 꽂이, 책장 미리보기 공통 컴포넌트 구현

### DIFF
--- a/src/components/common/BookImage.tsx
+++ b/src/components/common/BookImage.tsx
@@ -12,7 +12,7 @@ const onIntersection: IntersectionObserverCallback = (entries, io) => {
   });
 };
 
-interface Props {
+interface BookImageProps {
   lazy: boolean;
   threshold?: number;
   placeholder: string;
@@ -34,7 +34,7 @@ const BookImage = ({
   feed,
   alt,
   onImageClick,
-}: Props) => {
+}: BookImageProps) => {
   const [loaded, setLoaded] = useState(false);
   const imgRef = useRef<HTMLImageElement>(null);
 

--- a/src/components/common/BookImage.tsx
+++ b/src/components/common/BookImage.tsx
@@ -17,7 +17,7 @@ interface Props {
   threshold?: number;
   placeholder: string;
   src: string;
-  feed?: string;
+  feed: string;
   alt: string;
   onImageClick?: React.MouseEventHandler<HTMLDivElement>;
 }
@@ -65,21 +65,21 @@ const BookImage = ({
   }, [lazy, threshold]);
 
   const imageSize: imageSizeType = {
-    'type-1': 'w-[100%] pb-[100%] overflow-hidden',
-    'type-2': 'w-[50%] pb-[50%] overflow-hidden',
-    'type-3': 'w-[33%] pb-[33%] overflow-hidden',
-    'not-feed': `w-[90px] pb-[120px]`,
+    'feed-large': 'aspect-square w-[100%]',
+    'feed-medium': 'aspect-square w-[50%]',
+    'feed-small': 'aspect-square w-[33%]',
+    'not-feed-large': `w-[240px] h-[320px]`,
+    'not-feed-medium': `w-[120px] h-[160px]`,
+    'not-feed-small': `w-[72px] h-[96px]`,
   };
 
   return (
     <div
       onClick={feed ? onImageClick : undefined}
-      className={`${
-        feed ? imageSize[feed] : imageSize['not-feed']
-      } h-0 relative`}
+      className={`${imageSize[feed]}`}
     >
       <img
-        className='absolute t-0 l-0 w-[100%] h-[100%]'
+        className='w-[100%] h-[100%]'
         ref={imgRef}
         src={loaded ? src : placeholder}
         alt={alt}

--- a/src/components/common/BookShelf.tsx
+++ b/src/components/common/BookShelf.tsx
@@ -2,12 +2,12 @@ import Link from 'next/link';
 
 import BookImage from './BookImage';
 
-interface Props {
+interface BookShelfProps {
   size: 'small' | 'medium' | 'large';
   bookId: number;
 }
 
-const BookShelf = ({ size, bookId }: Props) => {
+const BookShelf = ({ size, bookId }: BookShelfProps) => {
   return (
     <Link
       href={`book/detail?bookId=${bookId}`}

--- a/src/components/common/BookShelf.tsx
+++ b/src/components/common/BookShelf.tsx
@@ -8,7 +8,7 @@ interface shelfSizeType {
   [key: string]: string;
 }
 
-const BookShelf = ({ size }) => {
+const BookShelf = ({ size }: Props) => {
   const shelfSize: shelfSizeType = {
     'shelf-large': 'aspect-square w-[100%]',
     'shelf-medium': 'aspect-square w-[50%]',
@@ -17,7 +17,9 @@ const BookShelf = ({ size }) => {
 
   return (
     <div
-      className={`${shelfSize['shelf-large']} bg-gray-400 flex justify-center items-center`}
+      className={`${
+        shelfSize[`shelf-${size}`]
+      } bg-gray-400 flex justify-center items-center`}
     >
       <BookImage
         lazy={true}
@@ -25,7 +27,7 @@ const BookShelf = ({ size }) => {
         src='https://image.yes24.com/momo/TopCate1261/MidCate008/70353017.jpg'
         alt='책장 속의 책입니다!'
         onImageClick={() => console.log('hi')}
-        feed='not-feed-large'
+        feed={`not-feed-${size}`}
       />
     </div>
   );

--- a/src/components/common/BookShelf.tsx
+++ b/src/components/common/BookShelf.tsx
@@ -6,14 +6,14 @@ interface shelfSizeType {
 
 const BookShelf = () => {
   const shelfSize: shelfSizeType = {
-    'type-1': 'aspect-square w-[100%]',
-    'type-2': 'aspect-square w-[50%]',
-    'type-3': 'aspect-square w-[33%]',
+    'shelf-large': 'aspect-square w-[100%]',
+    'shelf-medium': 'aspect-square w-[50%]',
+    'shelf-small': 'aspect-square w-[33%]',
   };
 
   return (
     <div
-      className={`${shelfSize['type-2']} bg-gray-400 flex justify-center items-center`}
+      className={`${shelfSize['shelf-large']} bg-gray-400 flex justify-center items-center`}
     >
       <BookImage
         lazy={true}
@@ -21,6 +21,7 @@ const BookShelf = () => {
         src='https://image.yes24.com/momo/TopCate1261/MidCate008/70353017.jpg'
         alt='책장 속의 책입니다!'
         onImageClick={() => console.log('hi')}
+        feed='not-feed-large'
       />
     </div>
   );

--- a/src/components/common/BookShelf.tsx
+++ b/src/components/common/BookShelf.tsx
@@ -1,15 +1,19 @@
+import Link from 'next/link';
+
 import BookImage from './BookImage';
 
 interface Props {
   size: 'small' | 'medium' | 'large';
+  bookId: number;
 }
 
-const BookShelf = ({ size }: Props) => {
+const BookShelf = ({ size, bookId }: Props) => {
   return (
-    <div
+    <Link
+      href={`book/detail?bookId=${bookId}`}
       className={`${
         shelfSize[`shelf-${size}`]
-      } bg-gray-400 flex justify-center items-center`}
+      } bg-gray-400 flex justify-center items-center cursor-pointer`}
     >
       <BookImage
         lazy={true}
@@ -19,7 +23,7 @@ const BookShelf = ({ size }: Props) => {
         onImageClick={() => console.log('hi')}
         feed={`not-feed-${size}`}
       />
-    </div>
+    </Link>
   );
 };
 

--- a/src/components/common/BookShelf.tsx
+++ b/src/components/common/BookShelf.tsx
@@ -4,17 +4,7 @@ interface Props {
   size: 'small' | 'medium' | 'large';
 }
 
-interface shelfSizeType {
-  [key: string]: string;
-}
-
 const BookShelf = ({ size }: Props) => {
-  const shelfSize: shelfSizeType = {
-    'shelf-large': 'aspect-square w-[100%]',
-    'shelf-medium': 'aspect-square w-[50%]',
-    'shelf-small': 'aspect-square w-[33%]',
-  };
-
   return (
     <div
       className={`${
@@ -34,3 +24,13 @@ const BookShelf = ({ size }: Props) => {
 };
 
 export default BookShelf;
+
+interface shelfSizeType {
+  [key: string]: string;
+}
+
+const shelfSize: shelfSizeType = {
+  'shelf-large': 'aspect-square w-[100%]',
+  'shelf-medium': 'aspect-square w-[50%]',
+  'shelf-small': 'aspect-square w-[33%]',
+};

--- a/src/components/common/BookShelf.tsx
+++ b/src/components/common/BookShelf.tsx
@@ -1,10 +1,14 @@
 import BookImage from './BookImage';
 
+interface Props {
+  size: 'small' | 'medium' | 'large';
+}
+
 interface shelfSizeType {
   [key: string]: string;
 }
 
-const BookShelf = () => {
+const BookShelf = ({ size }) => {
   const shelfSize: shelfSizeType = {
     'shelf-large': 'aspect-square w-[100%]',
     'shelf-medium': 'aspect-square w-[50%]',

--- a/src/components/common/BookShelf.tsx
+++ b/src/components/common/BookShelf.tsx
@@ -20,7 +20,6 @@ const BookShelf = ({ size, bookId }: Props) => {
         placeholder=''
         src='https://image.yes24.com/momo/TopCate1261/MidCate008/70353017.jpg'
         alt='책장 속의 책입니다!'
-        onImageClick={() => console.log('hi')}
         feed={`not-feed-${size}`}
       />
     </Link>

--- a/src/components/common/BookShelf.tsx
+++ b/src/components/common/BookShelf.tsx
@@ -1,0 +1,29 @@
+import BookImage from './BookImage';
+
+interface shelfSizeType {
+  [key: string]: string;
+}
+
+const BookShelf = () => {
+  const shelfSize: shelfSizeType = {
+    'type-1': 'aspect-square w-[100%]',
+    'type-2': 'aspect-square w-[50%]',
+    'type-3': 'aspect-square w-[33%]',
+  };
+
+  return (
+    <div
+      className={`${shelfSize['type-2']} bg-gray-400 flex justify-center items-center`}
+    >
+      <BookImage
+        lazy={true}
+        placeholder=''
+        src='https://image.yes24.com/momo/TopCate1261/MidCate008/70353017.jpg'
+        alt='책장 속의 책입니다!'
+        onImageClick={() => console.log('hi')}
+      />
+    </div>
+  );
+};
+
+export default BookShelf;

--- a/src/components/common/BookShelfPreviw.tsx
+++ b/src/components/common/BookShelfPreviw.tsx
@@ -1,13 +1,19 @@
+import Link from 'next/link';
+
 import BookImage from './BookImage';
 
 interface Props {
-  srcArr: string[];
+  imageSrcArr: string[];
+  memberId: string;
 }
 
-const BookShelfPreview = ({ srcArr }: Props) => {
+const BookShelfPreview = ({ imageSrcArr, memberId }: Props) => {
   return (
-    <div className='w-[100%] h-[130px] flex justify-evenly items-center bg-gray-400 cursor-pointer'>
-      {srcArr.map((src: string) => {
+    <Link
+      href={`bookshelf?memberId=${memberId}`}
+      className='w-[100%] h-[130px] flex justify-evenly items-center bg-gray-400 cursor-pointer'
+    >
+      {imageSrcArr.map((src: string) => {
         return (
           <>
             <BookImage
@@ -20,7 +26,7 @@ const BookShelfPreview = ({ srcArr }: Props) => {
           </>
         );
       })}
-    </div>
+    </Link>
   );
 };
 

--- a/src/components/common/BookShelfPreviw.tsx
+++ b/src/components/common/BookShelfPreviw.tsx
@@ -1,0 +1,24 @@
+import BookImage from './BookImage';
+
+const BookShelfPreview = ({ srcArr }) => {
+  return (
+    <div className='w-[100%] h-[130px] flex justify-evenly items-center bg-gray-400 cursor-pointer'>
+      {srcArr.map((src: string) => {
+        return (
+          <>
+            <BookImage
+              lazy={true}
+              placeholder=''
+              src={src}
+              alt='책장 미리보기 속의 책입니다!'
+              onImageClick={() => console.log('hi')}
+              feed='not-feed-small'
+            />
+          </>
+        );
+      })}
+    </div>
+  );
+};
+
+export default BookShelfPreview;

--- a/src/components/common/BookShelfPreviw.tsx
+++ b/src/components/common/BookShelfPreviw.tsx
@@ -2,12 +2,12 @@ import Link from 'next/link';
 
 import BookImage from './BookImage';
 
-interface Props {
+interface BookShelfPreviewProps {
   imageSrcArr: string[];
   memberId: string;
 }
 
-const BookShelfPreview = ({ imageSrcArr, memberId }: Props) => {
+const BookShelfPreview = ({ imageSrcArr, memberId }: BookShelfPreviewProps) => {
   return (
     <Link
       href={`bookshelf?memberId=${memberId}`}

--- a/src/components/common/BookShelfPreviw.tsx
+++ b/src/components/common/BookShelfPreviw.tsx
@@ -1,6 +1,10 @@
 import BookImage from './BookImage';
 
-const BookShelfPreview = ({ srcArr }) => {
+interface Props {
+  srcArr: string[];
+}
+
+const BookShelfPreview = ({ srcArr }: Props) => {
   return (
     <div className='w-[100%] h-[130px] flex justify-evenly items-center bg-gray-400 cursor-pointer'>
       {srcArr.map((src: string) => {

--- a/src/components/common/BookShelfPreviw.tsx
+++ b/src/components/common/BookShelfPreviw.tsx
@@ -11,7 +11,6 @@ const BookShelfPreview = ({ srcArr }) => {
               placeholder=''
               src={src}
               alt='책장 미리보기 속의 책입니다!'
-              onImageClick={() => console.log('hi')}
               feed='not-feed-small'
             />
           </>


### PR DESCRIPTION
## 📌 이슈 번호

- close #16 

## 👩‍💻 작업 내용

- 책꽂이 => small, medium, large 사이즈 및 클릭 시 클릭한 도서 상세 페이지로이동
![책꽂이](https://user-images.githubusercontent.com/60873508/235657907-d2d1a526-1531-4745-8fd9-8b9ee4029595.png)

- 책장 미리보기 => 클릭 시 특정 유저의 책장 페이지로 이동
![책장 미리보기](https://user-images.githubusercontent.com/60873508/235658085-7e8a98b8-9c5d-4650-8ffd-3ea86a570313.png)

- size 같은 경우 tailwindCSS에서 직접 props 데이터를 사용할 수 없어서 props 데이터에 따라 size를 정하는 방식으로 구현했습니다. 디자인이 완료되면 size 관련해서 좀더 구체적으로 정해야 할 것 같습니다. 

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

<!-- 참고할 사항이 있다면 적어주세요 -->
