### PR TITLE
feat: toggle 공통 컴포넌트 구현

### DIFF
--- a/custom.d.ts
+++ b/custom.d.ts
@@ -1,0 +1,8 @@
+import 'react';
+
+declare module 'react' {
+  interface StyleHTMLAttributes<T> extends React.HTMLAttributes<T> {
+    jsx?: boolean;
+    global?: boolean;
+  }
+}

--- a/src/components/common/Avartar.tsx
+++ b/src/components/common/Avartar.tsx
@@ -30,6 +30,7 @@ const Avatar = ({
         src={src}
         placeholder={placeholder}
         alt={alt}
+        feed='not-feed-small'
       />
     </div>
   );

--- a/src/components/common/Toggle/index.tsx
+++ b/src/components/common/Toggle/index.tsx
@@ -1,8 +1,14 @@
-const Toggle = () => {
+interface ToggleProps {
+  name: string;
+  disabled: true;
+  onChange(): void;
+}
+
+const Toggle = ({ name, disabled, onChange }) => {
   return (
     <>
       <label className='inline-block cursor-pointer select-none'>
-        <input type='checkbox' />
+        <input type='checkbox' name={name} disabled={disabled} />
         <div className='w-[64px] h-[30px] p-[2px] rounded-[15px] box-border	bg-gray-300 ease-out duration-200' />
       </label>
       <style jsx>

--- a/src/components/common/Toggle/index.tsx
+++ b/src/components/common/Toggle/index.tsx
@@ -1,0 +1,48 @@
+const Toggle = () => {
+  return (
+    <>
+      <label className='inline-block cursor-pointer select-none'>
+        <input type='checkbox' />
+        <div className='w-[64px] h-[30px] p-[2px] rounded-[15px] box-border	bg-gray-300 ease-out duration-200' />
+      </label>
+      <style jsx>
+        {`
+          div::after {
+            content: '';
+            position: relative;
+            left: 0;
+            display: block;
+            width: 26px;
+            height: 26px;
+            border-radius: 50%;
+            background-color: white;
+            transition: left 0.2s ease-out;
+          }
+
+          input {
+            display: none;
+
+            &:checked + div {
+              background: blue;
+            }
+
+            &:checked + div:after {
+              left: calc(100% - 26px);
+            }
+
+            &:disabled + div {
+              opacity: 0.7;
+              cursor: not-allowed;
+
+              &:after {
+                opacity: 0.7;
+              }
+            }
+          }
+        `}
+      </style>
+    </>
+  );
+};
+
+export default Toggle;

--- a/src/components/common/Toggle/index.tsx
+++ b/src/components/common/Toggle/index.tsx
@@ -1,14 +1,35 @@
+import useToggle from './useToggle';
+
 interface ToggleProps {
   name: string;
-  disabled: true;
+  on: boolean;
+  disabled?: boolean;
   onChange(): void;
 }
 
-const Toggle = ({ name, disabled, onChange }) => {
+const Toggle = ({
+  name,
+  on = false,
+  disabled = false,
+  onChange,
+}: ToggleProps) => {
+  const { isCheck, toggle } = useToggle(on);
+
+  const handleChange = () => {
+    toggle();
+    onChange();
+  };
+
   return (
     <>
       <label className='inline-block cursor-pointer select-none'>
-        <input type='checkbox' name={name} disabled={disabled} />
+        <input
+          type='checkbox'
+          name={name}
+          checked={isCheck}
+          disabled={disabled}
+          onChange={handleChange}
+        />
         <div className='w-[64px] h-[30px] p-[2px] rounded-[15px] box-border	bg-gray-300 ease-out duration-200' />
       </label>
       <style jsx>

--- a/src/components/common/Toggle/useToggle.ts
+++ b/src/components/common/Toggle/useToggle.ts
@@ -5,8 +5,8 @@ interface useToggleHookType {
   toggle: () => void;
 }
 
-const useToggle = (iniitialState: boolean): useToggleHookType => {
-  const [isCheck, setIsCheck] = useState(iniitialState);
+const useToggle = (initialState: boolean): useToggleHookType => {
+  const [isCheck, setIsCheck] = useState(initialState);
   const toggle = useCallback(() => setIsCheck((isCheck) => !isCheck), []);
 
   return { isCheck, toggle };

--- a/src/components/common/Toggle/useToggle.ts
+++ b/src/components/common/Toggle/useToggle.ts
@@ -1,0 +1,10 @@
+import { useCallback, useState } from 'react';
+
+const useToggle = (iniitialState: boolean) => {
+  const [state, setState] = useState(iniitialState);
+  const toggle = useCallback(() => setState((state: boolean) => !state), []);
+
+  return [state, toggle];
+};
+
+export default useToggle;

--- a/src/components/common/Toggle/useToggle.ts
+++ b/src/components/common/Toggle/useToggle.ts
@@ -1,10 +1,15 @@
 import { useCallback, useState } from 'react';
 
-const useToggle = (iniitialState: boolean) => {
-  const [state, setState] = useState(iniitialState);
-  const toggle = useCallback(() => setState((state: boolean) => !state), []);
+interface useToggleHookType {
+  isCheck: boolean;
+  toggle: () => void;
+}
 
-  return [state, toggle];
+const useToggle = (iniitialState: boolean): useToggleHookType => {
+  const [isCheck, setIsCheck] = useState(iniitialState);
+  const toggle = useCallback(() => setIsCheck((isCheck) => !isCheck), []);
+
+  return { isCheck, toggle };
 };
 
 export default useToggle;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": ["next-env.d.ts", "custom.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## 📌 이슈 번호

- close #30 

## 👩‍💻 작업 내용

<!-- 자세히 쓰기 - 이미지가 필요한 경우 첨부하기, 영상도 ok -->
- 마크업 작업시에 tailwind CSS를 통해 after, checked, + 선택자를 처리하는게 쉽지 않아서 style jsx 개념을 도입해서 css 작업을 진행하였습니다.
- toggle 버튼 클릭 시 호출 되는 함수에 전달되는 인자(boolean 데이터)를 공통 컴포넌트 또는 Hook에서 설정을 하려고 했습니다만 개인적으로 각자 문제가 있어 공통 컴포넌트를 호출 하는 곳에서 처리하도록 구현 했습니다.
  - 공통 컴포넌트에서는 useEffect를 통해 처리할 수 있지만 처음 component가 mount될 때 호출되지 않아도 되는 함수가 호출되는 문제와 공통 컴포넌트 특정 페이지의 state 까지 관리해야할까?라는 의문이 생겨 일단 배제했습니다.
  - Hook에서는 setState 시에 수정하면 되지만 위와 같이 역할과 관련해 의문이 생겨 배제했습니다.
![localhost_3000-Chrome-2023-05-03-20-07-39](https://user-images.githubusercontent.com/60873508/235900166-de3fa59b-7ad6-4834-997d-5cbaef85d7c5.gif)

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

- style jsx를 사용하니 로컬에서는 type check에 문제가 없었지만 배포 환경에서는 문제가 발생해 custom.d.ts 파일을 전역에 추가해 해당 에러를 해결하였습니다. 앞으로 local이나 배포 환경에서 type 관련 문제가 발생한다면 tsconfig.json에서 custom.d.ts파일을 import 하기 때문에 type 관련 문제를 처리할 수 있을 것 같습니다,
