### PR TITLE
feat: 도서 검색 페이지 제작1

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "react-datepicker": "^4.11.0",
     "react-dom": "18.2.0",
     "recoil": "^0.7.7",
+    "tailwind-styled-components": "^2.2.0",
     "tailwindcss": "3.3.2",
     "typescript": "5.0.4",
     "yarn": "^1.22.19"

--- a/src/api/book.ts
+++ b/src/api/book.ts
@@ -6,19 +6,16 @@ const KAKAO_BOOK_SEARCH_API_URL =
   process.env.NEXT_PUBLIC_KAKAO_BOOK_SEARCH_API_URL;
 
 export const getBookSearchResultData = async (query: string) => {
-  console.log(query);
   try {
-    const res = await axios.get(
-      `${KAKAO_BOOK_SEARCH_API_URL}?query=${query}&size=5`,
-      {
-        headers: {
-          Authorization: `KakaoAK ${KAKAO_REST_API_KEY}`,
-        },
+    const {
+      data: { documents },
+    } = await axios.get(`${KAKAO_BOOK_SEARCH_API_URL}?query=${query}&size=5`, {
+      headers: {
+        Authorization: `KakaoAK ${KAKAO_REST_API_KEY}`,
       },
-    );
+    });
 
-    console.log(res);
-    return res;
+    return documents;
   } catch {
     throw new Error('데이터 패치 실패');
   }

--- a/src/api/book.ts
+++ b/src/api/book.ts
@@ -1,0 +1,25 @@
+import axios from 'axios';
+
+import { KAKAO_REST_API_KEY } from '@/constants/auth';
+
+const KAKAO_BOOK_SEARCH_API_URL =
+  process.env.NEXT_PUBLIC_KAKAO_BOOK_SEARCH_API_URL;
+
+export const getBookSearchResultData = async (query: string) => {
+  console.log(query);
+  try {
+    const res = await axios.get(
+      `${KAKAO_BOOK_SEARCH_API_URL}?query=${query}&size=5`,
+      {
+        headers: {
+          Authorization: `KakaoAK ${KAKAO_REST_API_KEY}`,
+        },
+      },
+    );
+
+    console.log(res);
+    return res;
+  } catch {
+    throw new Error('데이터 패치 실패');
+  }
+};

--- a/src/api/book.ts
+++ b/src/api/book.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 
 import { KAKAO_REST_API_KEY } from '@/constants/auth';
+import { BookSearchResulListItem } from '@/types/book';
 
 const KAKAO_BOOK_SEARCH_API_URL =
   process.env.NEXT_PUBLIC_KAKAO_BOOK_SEARCH_API_URL;
@@ -9,13 +10,20 @@ export const getBookSearchResultData = async (query: string) => {
   try {
     const {
       data: { documents },
-    } = await axios.get(`${KAKAO_BOOK_SEARCH_API_URL}?query=${query}&size=5`, {
-      headers: {
-        Authorization: `KakaoAK ${KAKAO_REST_API_KEY}`,
+    } = await axios.get<{ documents: BookSearchResulListItem[] }>(
+      `${KAKAO_BOOK_SEARCH_API_URL}?query=${query}&size=5`,
+      {
+        headers: {
+          Authorization: `KakaoAK ${KAKAO_REST_API_KEY}`,
+        },
       },
-    });
+    );
 
-    return documents;
+    if (documents.length > 0) {
+      return documents;
+    } else {
+      return [];
+    }
   } catch {
     throw new Error('데이터 패치 실패');
   }

--- a/src/components/book/search/SearchResultList.tsx
+++ b/src/components/book/search/SearchResultList.tsx
@@ -1,23 +1,22 @@
 import SearchResultListItem from '@/components/common/ListItem/SearchResultListItem';
 
-const SearchResultList = () => {
+interface SearchResultListProps {
+  listData: any;
+}
+
+const SearchResultList = ({ listData }: SearchResultListProps) => {
   return (
     <>
-      <SearchResultListItem
-        src='https://image.yes24.com/goods/15058512/XL'
-        imageSize='not-feed-small'
-        title='미움 받을 용기'
-        author='기시미 이치로'
-        publisher='이치로 출판사'
-      />
-
-      <SearchResultListItem
-        src='https://image.yes24.com/goods/15058512/XL'
-        imageSize='not-feed-small'
-        title='미움 받을 용기'
-        author='기시미 이치로'
-        publisher='이치로 출판사'
-      />
+      {listData.map(({ thumbnail, title, authors, publisher, isbn }) => (
+        <SearchResultListItem
+          key={isbn}
+          src={thumbnail}
+          imageSize='not-feed-small'
+          title={title}
+          author={authors[0]}
+          publisher={publisher}
+        />
+      ))}
     </>
   );
 };

--- a/src/components/book/search/SearchResultList.tsx
+++ b/src/components/book/search/SearchResultList.tsx
@@ -13,7 +13,7 @@ const SearchResultList = ({ listData }: SearchResultListProps) => {
           src={thumbnail}
           imageSize='not-feed-small'
           title={title}
-          author={authors[0]}
+          author={authors.slice(0, 2)}
           publisher={publisher}
         />
       ))}

--- a/src/components/book/search/SearchResultList.tsx
+++ b/src/components/book/search/SearchResultList.tsx
@@ -1,0 +1,25 @@
+import SearchResultListItem from '@/components/common/ListItem/SearchResultListItem';
+
+const SearchResultList = () => {
+  return (
+    <>
+      <SearchResultListItem
+        src='https://image.yes24.com/goods/15058512/XL'
+        imageSize='not-feed-small'
+        title='미움 받을 용기'
+        author='기시미 이치로'
+        publisher='이치로 출판사'
+      />
+
+      <SearchResultListItem
+        src='https://image.yes24.com/goods/15058512/XL'
+        imageSize='not-feed-small'
+        title='미움 받을 용기'
+        author='기시미 이치로'
+        publisher='이치로 출판사'
+      />
+    </>
+  );
+};
+
+export default SearchResultList;

--- a/src/components/book/search/SearchResultList.tsx
+++ b/src/components/book/search/SearchResultList.tsx
@@ -1,7 +1,8 @@
 import SearchResultListItem from '@/components/common/ListItem/SearchResultListItem';
+import { BookSearchResulListItem } from '@/types/book';
 
 interface SearchResultListProps {
-  listData: any;
+  listData: BookSearchResulListItem[];
 }
 
 const SearchResultList = ({ listData }: SearchResultListProps) => {

--- a/src/components/common/ListItem/SearchResultListItem.tsx
+++ b/src/components/common/ListItem/SearchResultListItem.tsx
@@ -1,6 +1,6 @@
 import BookImage from '../ImageComponent';
 
-interface SearchResultProps {
+interface SearchResultListItemProps {
   src: string;
   imageSize: string;
   title: string;
@@ -8,13 +8,13 @@ interface SearchResultProps {
   publisher: string;
 }
 
-const SearchResult = ({
+const SearchResultListItem = ({
   src,
   imageSize,
   title,
   author,
   publisher,
-}: SearchResultProps) => {
+}: SearchResultListItemProps) => {
   return (
     <div className='w-[100%] flex items-center bg-yellow-500 px-[20px] py-[15px] cursor-pointer'>
       <div className='w-[50%]'>
@@ -35,4 +35,4 @@ const SearchResult = ({
   );
 };
 
-export default SearchResult;
+export default SearchResultListItem;

--- a/src/components/common/ListItem/SearchResultListItem.tsx
+++ b/src/components/common/ListItem/SearchResultListItem.tsx
@@ -4,7 +4,7 @@ interface SearchResultListItemProps {
   src: string;
   imageSize: string;
   title: string;
-  author: string;
+  author: string[];
   publisher: string;
 }
 
@@ -28,7 +28,7 @@ const SearchResultListItem = ({
       </div>
       <div className='w-[50%] flex flex-col font-bold text-[15px]'>
         <span>{title}</span>
-        <span>{author}</span>
+        <span>{`${author[0]} ${author[1] ? `|  ${author[1]}` : ''}`}</span>
         <span>{publisher}</span>
       </div>
     </div>

--- a/src/components/common/SearchInput.tsx
+++ b/src/components/common/SearchInput.tsx
@@ -2,10 +2,10 @@ import Image from 'next/image';
 import { useState } from 'react';
 
 interface Props {
-  getSearchData(text: string): Array<any>; // fetch한 데이터의 type이 정해지지 않은 관계로 any로 설정
+  onSubmit(keywrod: string): void;
 }
 
-const SearchInput = ({ getSearchData }: Props) => {
+const SearchInput = ({ onSubmit }: Props) => {
   const [inputData, setInputData] = useState('');
   const [isError, setIsError] = useState(false);
 
@@ -14,6 +14,8 @@ const SearchInput = ({ getSearchData }: Props) => {
   };
 
   const onClickSearchButton = () => {
+    onSubmit(inputData);
+
     if (!inputData) {
       setIsError(true);
       return;
@@ -22,7 +24,6 @@ const SearchInput = ({ getSearchData }: Props) => {
     if (isError) {
       setIsError(false);
     }
-    getSearchData(inputData);
   };
 
   return (
@@ -43,7 +44,7 @@ const SearchInput = ({ getSearchData }: Props) => {
           onClick={onClickSearchButton}
         >
           <Image
-            src='./images/search.svg'
+            src='../images/search.svg'
             width={35}
             height={35}
             alt='검색 아이콘'

--- a/src/pages/book/search/index.tsx
+++ b/src/pages/book/search/index.tsx
@@ -11,7 +11,11 @@ import SearchInput from '@/components/common/SearchInput';
 const BookSearchPage = () => {
   const [searchKeyword, setSearchKeyword] = useState('');
 
-  const { data: bookSearchResultList, isLoading } = useQuery(
+  const {
+    data: bookSearchResultList,
+    isLoading,
+    isError,
+  } = useQuery(
     ['book', 'search', 'result', 'list', searchKeyword],
     () => getBookSearchResultData(searchKeyword),
     {
@@ -23,12 +27,13 @@ const BookSearchPage = () => {
     setSearchKeyword(keyword);
   };
 
+  if (isLoading) return <h1>로딩 중 입니다.</h1>;
+  if (isError) return <h1>에러가 발생하였습니다.</h1>;
+
   return (
     <Container>
       <SearchInput onSubmit={onSubmit} />
-      {!isLoading && bookSearchResultList && (
-        <SearchResultList listData={bookSearchResultList} />
-      )}
+      <SearchResultList listData={bookSearchResultList} />
       <BottomNav />
     </Container>
   );

--- a/src/pages/book/search/index.tsx
+++ b/src/pages/book/search/index.tsx
@@ -1,15 +1,32 @@
+import { useQuery } from '@tanstack/react-query';
 import React from 'react';
+import { useState } from 'react';
 import tw from 'tailwind-styled-components';
 
+import { getBookSearchResultData } from '@/api/book';
 import SearchResultList from '@/components/book/search/SearchResultList';
 import BottomNav from '@/components/common/BottomNav';
 import SearchInput from '@/components/common/SearchInput';
 
 const BookSearchPage = () => {
+  const [searchKeyword, setSearchKeyword] = useState('');
+
+  const { data: bookSearchResultList, isLoading } = useQuery(
+    ['book', 'search', 'result', 'list', searchKeyword],
+    () => getBookSearchResultData(searchKeyword),
+    {
+      enabled: !!searchKeyword,
+    },
+  );
+
+  const onSubmit = (keyword: string) => {
+    setSearchKeyword(keyword);
+  };
+
   return (
     <Container>
-      <SearchInput />
-      <SearchResultList />
+      <SearchInput onSubmit={onSubmit} />
+      {!isLoading && <SearchResultList listData={bookSearchResultList} />}
       <BottomNav />
     </Container>
   );

--- a/src/pages/book/search/index.tsx
+++ b/src/pages/book/search/index.tsx
@@ -1,7 +1,30 @@
 import React from 'react';
+import tw from 'tailwind-styled-components';
+
+import BottomNav from '@/components/common/BottomNav';
+import SearchResult from '@/components/common/ListItem/SearchResult';
+import SearchInput from '@/components/common/SearchInput';
 
 const BookSearchPage = () => {
-  return <div>도서 검색 페이지</div>;
+  return (
+    <Container>
+      <SearchInput />
+      <SearchResult
+        src='https://image.yes24.com/goods/15058512/XL'
+        imageSize='not-feed-small'
+        title='미움 받을 용기'
+        author='기시미 이치로'
+        publisher='이치로 출판사'
+      />
+      <BottomNav />
+    </Container>
+  );
 };
 
 export default BookSearchPage;
+
+const Container = tw.div`
+  w-[90%]
+  mx-auto
+  mt-8
+`;

--- a/src/pages/book/search/index.tsx
+++ b/src/pages/book/search/index.tsx
@@ -1,21 +1,15 @@
 import React from 'react';
 import tw from 'tailwind-styled-components';
 
+import SearchResultList from '@/components/book/search/SearchResultList';
 import BottomNav from '@/components/common/BottomNav';
-import SearchResult from '@/components/common/ListItem/SearchResult';
 import SearchInput from '@/components/common/SearchInput';
 
 const BookSearchPage = () => {
   return (
     <Container>
       <SearchInput />
-      <SearchResult
-        src='https://image.yes24.com/goods/15058512/XL'
-        imageSize='not-feed-small'
-        title='미움 받을 용기'
-        author='기시미 이치로'
-        publisher='이치로 출판사'
-      />
+      <SearchResultList />
       <BottomNav />
     </Container>
   );

--- a/src/pages/book/search/index.tsx
+++ b/src/pages/book/search/index.tsx
@@ -26,7 +26,9 @@ const BookSearchPage = () => {
   return (
     <Container>
       <SearchInput onSubmit={onSubmit} />
-      {!isLoading && <SearchResultList listData={bookSearchResultList} />}
+      {!isLoading && bookSearchResultList && (
+        <SearchResultList listData={bookSearchResultList} />
+      )}
       <BottomNav />
     </Container>
   );

--- a/src/types/book.d.ts
+++ b/src/types/book.d.ts
@@ -1,0 +1,7 @@
+export interface BookSearchResulListItem {
+  thumbnail: string;
+  title: string;
+  authors: string[];
+  publisher: string;
+  isbn: string;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2415,6 +2415,18 @@ synckit@^0.8.5:
     "@pkgr/utils" "^2.3.1"
     tslib "^2.5.0"
 
+tailwind-merge@^1.3.0:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/tailwind-merge/-/tailwind-merge-1.12.0.tgz#747d09d64a25a4864150e8930f8e436866066cc8"
+  integrity sha512-Y17eDp7FtN1+JJ4OY0Bqv9OA41O+MS8c1Iyr3T6JFLnOgLg3EvcyMKZAnQ8AGyvB5Nxm3t9Xb5Mhe139m8QT/g==
+
+tailwind-styled-components@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tailwind-styled-components/-/tailwind-styled-components-2.2.0.tgz#c1f7d680a2798d3a30ec38833d3fd67166008fb8"
+  integrity sha512-Ogemwk0p69aU8WE/ooJZHjqstdJgT5R6HGU6TFz2uSnveSEtvW+C6aWOjGCvCr5H/bREv0IbbQ4yODknRrLBRQ==
+  dependencies:
+    tailwind-merge "^1.3.0"
+
 tailwindcss@3.3.2:
   version "3.3.2"
   resolved "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.3.2.tgz"


### PR DESCRIPTION
## 📌 이슈 번호

- close #71 

## 👩‍💻 작업 내용

- 마크업
- API URL 환경변수로 등록
- API 통해 데이터 fetch
- 화면에 render
- type 설정


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

- 남은 기능까지 구현하였을 경우 commit 개수가 많아질 것 같아 2개로 나눠 PR 올리겠습니다~
- 일단은 검색 시에 5개의 item이 render 되도록 구현하였습니다.
- authors 데이터 같은 경우 배열로 넘어와서 1개에서 많게는 여러개가 있을 것이라 예상이 되어 최대 2명의 이름만 render 하도록 처리하였습니다~ 
