### PR TITLE
Feat/#75 modal component

### DIFF
--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -1,9 +1,16 @@
 import React, { useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
+import { useSetRecoilState } from 'recoil';
+
+import { modalStateAtom } from '@/recoil/modal';
 
 const BackDrop = () => {
+  const setModal = useSetRecoilState(modalStateAtom);
   return (
-    <div className='fixed w-full h-screen z-20 bg-[rgba(0,0,0,0.75)] left-0 top-0' />
+    <div
+      className='fixed w-full h-screen z-20 bg-[rgba(0,0,0,0.75)] left-0 top-0'
+      onClick={() => setModal(false)}
+    />
   );
 };
 

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -1,0 +1,38 @@
+import React, { useEffect, useState } from 'react';
+import ReactDOM from 'react-dom';
+
+const BackDrop = () => {
+  return (
+    <div className='fixed w-full h-screen z-20 bg-[rgba(0,0,0,0.75)] left-0 top-0' />
+  );
+};
+
+const ModalOverlay = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <div className='fixed bg-[white] shadow-[0_2px_8px_rgba(0,0,0,0.25)] z-30 p-4 rounded-[14px] top-12 mx-auto inset-x-0 w-[21rem] animate-slideDown'>
+      {children}
+    </div>
+  );
+};
+
+const Modal = ({ children }: { children: React.ReactNode }) => {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+
+    return () => setMounted(false);
+  }, []);
+
+  const element =
+    typeof window !== 'undefined' && document.getElementById('portal');
+
+  return mounted && element ? (
+    <>
+      {ReactDOM.createPortal(<BackDrop />, element)}
+      {ReactDOM.createPortal(<ModalOverlay>{children}</ModalOverlay>, element)}
+    </>
+  ) : null;
+};
+
+export default Modal;

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -6,6 +6,7 @@ export default function Document() {
       <Head />
       <body>
         <Main />
+        <div id='portal' />
         <NextScript />
       </body>
     </Html>

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -1,7 +1,18 @@
 import React from 'react';
+import { useRecoilState } from 'recoil';
+
+import Modal from '@/components/common/Modal';
+import { modalStateAtom } from '@/recoil/modal';
 
 const ProfilePage = () => {
-  return <div>프로필 페이지</div>;
+  const [modal, setModal] = useRecoilState(modalStateAtom);
+
+  return (
+    <div className='h-screen p-5 border-2 border-red-500'>
+      <button onClick={() => setModal(true)}>모달 on</button>
+      {modal && <Modal>모달 내용</Modal>}
+    </div>
+  );
 };
 
 export default ProfilePage;

--- a/src/recoil/modal.ts
+++ b/src/recoil/modal.ts
@@ -1,0 +1,6 @@
+import { atom } from "recoil";
+
+export const modalStateAtom = atom<boolean>({
+    key:'modalState',
+    default:false,
+})

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,6 +7,15 @@ module.exports = {
   ],
   theme: {
     extend: {
+      keyframes : { 
+        slideDown : {
+          from: { opacity: "0", transform: "translateY(-3rem)"},
+          to: { opacity: "1", transform: "translateY(0)"},
+        },    
+      },
+      animation: {
+        slideDown: "slideDown 300ms ease-out forwards"
+      },
       backgroundImage: {
         'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',
         'gradient-conic':
@@ -17,6 +26,7 @@ module.exports = {
       xs: { max: '390px' },
       xxs: { max: '280px' },
     },
+    
   },
   plugins: [],
 };


### PR DESCRIPTION
## 📌 이슈 번호

- close #75 

## 👩‍💻 작업 내용
- 리액트 포탈을 이용하여 모달 구현
- tailwind.config.js에 사용자 정의 애니메이션 구현 후 적용
- atom을 이용하여 모달을 전역적으로 관리
<img width="321" alt="스크린샷 2023-05-17 오후 10 22 30" src="https://github.com/dugeun-dugeun-project/frontend/assets/91203029/bc920f6a-e9a2-4cc2-8624-a0d2211a2f93">


<!-- 자세히 쓰기 - 이미지가 필요한 경우 첨부하기, 영상도 ok -->

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

<!-- 참고할 사항이 있다면 적어주세요 -->
- 포탈을 쓰는 이유
1. 스크린리더가 렌더링되는 HTML 코드를 해석할 때 모달이라는 존재를 인식할 수 없게 되고, 의미적으로나 구조적인 관점에서 모달이 모든 영역에 위에 깔린 것인지 알지 못하기 때문
2. 앨리먼트를 다른 돔으로 옮겨 CSS 상속 구조에서 벗어나기 위함