### PR TITLE
feat: 독서 모임 상세페이지 레이아웃 구현

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,10 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-}
+  images: {
+    domains: ['via.placeholder.com'],
+    formats: ['image/webp'],
+  },
+};
 
-module.exports = nextConfig
+module.exports = nextConfig;

--- a/src/components/common/ImageComponent.tsx
+++ b/src/components/common/ImageComponent.tsx
@@ -80,7 +80,7 @@ const ImageComponent = ({
   return (
     <div
       onClick={size ? onImageClick : undefined}
-      className={`${imageSize[size]} ${imgStyle}`}
+      className={imgStyle && `${imageSize[size]} ${imgStyle}`}
     >
       <img
         className='w-[100%] h-[100%]'

--- a/src/components/common/Tab/TabItem.tsx
+++ b/src/components/common/Tab/TabItem.tsx
@@ -2,11 +2,12 @@ import Link from 'next/link';
 
 interface Props {
   title: string;
-  active?: boolean;
+  active: boolean;
   navigatePath: string;
+  tabPosition: string;
 }
 
-const TabItem = ({ title, active, navigatePath }: Props) => {
+const TabItem = ({ title, active, navigatePath, tabPosition }: Props) => {
   return (
     <Link
       className={`w-[50%] inline-flex justify-center items-end w-[140px] h-[60px] border-b-2 cursor-pointer ${
@@ -14,9 +15,12 @@ const TabItem = ({ title, active, navigatePath }: Props) => {
           ? 'border-blue-800 text-blue-800'
           : 'border-gray-400 text-gray-400'
       }`}
+      data-position={tabPosition}
       href={navigatePath}
     >
-      <div className='pb-[7px]'>{title}</div>
+      <div className='pb-[7px]' data-position={tabPosition}>
+        {title}
+      </div>
     </Link>
   );
 };

--- a/src/components/common/Tab/index.tsx
+++ b/src/components/common/Tab/index.tsx
@@ -1,31 +1,45 @@
+import { useState } from 'react';
+
 import TabItem from './TabItem';
 
 interface Props {
-  lefttext: string;
-  righttext: string;
+  leftText: string;
+  rightText: string;
   leftNavigatePath: string;
   rightNavigatePath: string;
-  position: 'left' | 'right';
+  defaultPosition: 'left' | 'right';
 }
 
 const Tab = ({
-  lefttext,
-  righttext,
+  leftText,
+  rightText,
   leftNavigatePath,
   rightNavigatePath,
-  position,
+  defaultPosition,
 }: Props) => {
+  const [tabPosition, setTabPosition] = useState(defaultPosition);
+
   return (
-    <div className='w-[100%] flex justify-center'>
+    <div
+      className='w-[100%] flex justify-center'
+      onClick={(e) => {
+        if (!(e.target instanceof HTMLElement)) return;
+        const position = e.target.dataset.position;
+        if (position === 'left') setTabPosition('left');
+        if (position === 'right') setTabPosition('right');
+      }}
+    >
       <TabItem
-        title={lefttext}
-        active={position === 'left'}
+        title={leftText}
+        active={tabPosition === 'left'}
         navigatePath={leftNavigatePath}
+        tabPosition='left'
       />
       <TabItem
-        title={righttext}
-        active={position === 'right'}
+        title={rightText}
+        active={tabPosition === 'right'}
         navigatePath={rightNavigatePath}
+        tabPosition='right'
       />
     </div>
   );

--- a/src/components/recruit/RecruitTab.tsx
+++ b/src/components/recruit/RecruitTab.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import Tab from '../common/Tab';
+
+function RecruitTab() {
+  return (
+    <Tab
+      leftText='모임설명'
+      rightText='채팅'
+      leftNavigatePath='/recruit/detail'
+      rightNavigatePath='/recruit/chatting'
+      defaultPosition='left'
+    />
+  );
+}
+
+export default RecruitTab;

--- a/src/layout/Layout.tsx
+++ b/src/layout/Layout.tsx
@@ -1,0 +1,7 @@
+import React, { ReactNode } from 'react';
+
+function Layout({ children }: { children: ReactNode }) {
+  return <div>{children}</div>;
+}
+
+export default Layout;

--- a/src/layout/RecruitLayout.tsx
+++ b/src/layout/RecruitLayout.tsx
@@ -1,0 +1,16 @@
+import React, { ReactNode } from 'react';
+
+import RecruitTab from '@/components/recruit/RecruitTab';
+
+import Layout from './Layout';
+
+function RecruitLayout({ children }: { children: ReactNode }) {
+  return (
+    <Layout>
+      <RecruitTab />
+      {children}
+    </Layout>
+  );
+}
+
+export default RecruitLayout;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -6,19 +6,27 @@ import {
   QueryClientProvider,
 } from '@tanstack/react-query';
 import type { AppProps } from 'next/app';
-import React from 'react';
+import React, { ReactElement } from 'react';
 import { RecoilRoot } from 'recoil';
 
 import LoginModal from '@/components/auth/LoginModal';
+import Layout from '@/layout/Layout';
+import { NextPageWithLayout } from '@/types/layout';
 
-export default function App({ Component, pageProps }: AppProps) {
+interface AppPropsWithLayout extends AppProps {
+  Component: NextPageWithLayout;
+}
+
+export default function App({ Component, pageProps }: AppPropsWithLayout) {
   const [queryClient] = React.useState(() => new QueryClient());
+  const getLayout =
+    Component.getLayout || ((page: ReactElement) => <Layout>{page}</Layout>);
 
   return (
     <QueryClientProvider client={queryClient}>
       <Hydrate state={pageProps.dehydratedState}>
         <RecoilRoot>
-          <Component {...pageProps} />
+          {getLayout(<Component {...pageProps} />)}
           <LoginModal />
         </RecoilRoot>
       </Hydrate>

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,8 +1,8 @@
-import { Html, Head, Main, NextScript } from 'next/document';
+import { Head, Html, Main, NextScript } from 'next/document';
 
 export default function Document() {
   return (
-    <Html lang='en'>
+    <Html lang='ko'>
       <Head />
       <body>
         <Main />

--- a/src/pages/recruit/chatting.tsx
+++ b/src/pages/recruit/chatting.tsx
@@ -1,6 +1,5 @@
 import React, { ReactElement } from 'react';
 
-import Layout from '@/layout/Layout';
 import RecruitLayout from '@/layout/RecruitLayout';
 import { NextPageWithLayout } from '@/types/layout';
 
@@ -9,10 +8,6 @@ const RecruitChattingPage: NextPageWithLayout = () => {
 };
 
 RecruitChattingPage.getLayout = function getLayout(page: ReactElement) {
-  return (
-    <Layout>
-      <RecruitLayout>{page}</RecruitLayout>
-    </Layout>
-  );
+  return <RecruitLayout>{page}</RecruitLayout>;
 };
 export default RecruitChattingPage;

--- a/src/pages/recruit/chatting.tsx
+++ b/src/pages/recruit/chatting.tsx
@@ -1,0 +1,18 @@
+import React, { ReactElement } from 'react';
+
+import Layout from '@/layout/Layout';
+import RecruitLayout from '@/layout/RecruitLayout';
+import { NextPageWithLayout } from '@/types/layout';
+
+const RecruitChattingPage: NextPageWithLayout = () => {
+  return <>chatting</>;
+};
+
+RecruitChattingPage.getLayout = function getLayout(page: ReactElement) {
+  return (
+    <Layout>
+      <RecruitLayout>{page}</RecruitLayout>
+    </Layout>
+  );
+};
+export default RecruitChattingPage;

--- a/src/pages/recruit/detail.tsx
+++ b/src/pages/recruit/detail.tsx
@@ -1,7 +1,9 @@
 import Image from 'next/image';
-import React from 'react';
+import React, { ReactElement } from 'react';
 
 import Avatar from '@/components/common/Avartar';
+import Layout from '@/layout/Layout';
+import RecruitLayout from '@/layout/RecruitLayout';
 import { NextPageWithLayout } from '@/types/layout';
 
 const DUMMY = {
@@ -91,6 +93,14 @@ const RecruitDetailPage: NextPageWithLayout = () => {
         <button>가입</button>
       )}
     </main>
+  );
+};
+
+RecruitDetailPage.getLayout = function getLayout(page: ReactElement) {
+  return (
+    <Layout>
+      <RecruitLayout>{page}</RecruitLayout>
+    </Layout>
   );
 };
 

--- a/src/pages/recruit/detail.tsx
+++ b/src/pages/recruit/detail.tsx
@@ -2,7 +2,6 @@ import Image from 'next/image';
 import React, { ReactElement } from 'react';
 
 import Avatar from '@/components/common/Avartar';
-import Layout from '@/layout/Layout';
 import RecruitLayout from '@/layout/RecruitLayout';
 import { NextPageWithLayout } from '@/types/layout';
 
@@ -97,11 +96,7 @@ const RecruitDetailPage: NextPageWithLayout = () => {
 };
 
 RecruitDetailPage.getLayout = function getLayout(page: ReactElement) {
-  return (
-    <Layout>
-      <RecruitLayout>{page}</RecruitLayout>
-    </Layout>
-  );
+  return <RecruitLayout>{page}</RecruitLayout>;
 };
 
 export default RecruitDetailPage;

--- a/src/pages/recruit/detail.tsx
+++ b/src/pages/recruit/detail.tsx
@@ -1,7 +1,98 @@
-import React from 'react';
+import Image from 'next/image';
+import React, { ReactElement } from 'react';
 
-const RecruitDetailPage = () => {
-  return <div>독서 모집 공보 디테일 페이지</div>;
+import Avatar from '@/components/common/Avartar';
+import Layout from '@/layout/Layout';
+import RecruitLayout from '@/layout/RecruitLayout';
+import { NextPageWithLayout } from '@/types/layout';
+
+const DUMMY = {
+  data: {
+    groupId: 1,
+    groupName: '독서모임~',
+    groupImg: 'https://via.placeholder.com/400x200',
+    endDate: '2023-06-10',
+    online: false,
+    people: 10,
+    location: '서울',
+    description: '독서 모임입니다~',
+    notice: '공지입니다',
+    isAdmin: false,
+    isMember: true,
+    admin: {
+      userId: 1,
+      nickname: '일이삼',
+      profileImg: 'https://via.placeholder.com/40',
+    },
+    user: [
+      {
+        userId: 1,
+        nickname: '일일일',
+        profileImg: 'https://via.placeholder.com/40',
+      },
+      {
+        userId: 2,
+        nickname: '이이이',
+        profileImg: 'https://via.placeholder.com/40',
+      },
+      {
+        userId: 3,
+        nickname: '삼삼삼',
+        profileImg: 'https://via.placeholder.com/40',
+      },
+    ],
+  },
+};
+
+const RecruitDetailPage: NextPageWithLayout = () => {
+  return (
+    <main className='flex flex-col'>
+      {DUMMY.data.isMember && DUMMY.data.notice && (
+        <p className='bg-slate-100'>{DUMMY.data.notice}</p>
+      )}
+      <h1>{DUMMY.data.groupName}</h1>
+      <Image
+        src={DUMMY.data.groupImg}
+        width={400}
+        height={200}
+        alt='모임 설명 이미지'
+        priority
+      />
+      <p>{DUMMY.data.endDate}</p>
+      <p>{DUMMY.data.online ? '온라인' : '오프라인'}</p>
+      <p>{!DUMMY.data.online && DUMMY.data.location}</p>
+      <p>{DUMMY.data.description}</p>
+      <div className='flex items-center'>
+        <span>모임장</span>
+        <Avatar
+          src={DUMMY.data.admin.profileImg}
+          shape='circle'
+          alt='모임장 프로필 이미지'
+          lazy={false}
+          placeholder=''
+        />
+      </div>
+      <div className='flex'>
+        {DUMMY.data.user.map((member) => (
+          <Avatar
+            key={member.userId}
+            src={member.profileImg}
+            shape='circle'
+            alt='구성원 프로필 이미지'
+            lazy={false}
+            placeholder=''
+          />
+        ))}
+      </div>
+      {DUMMY.data.isAdmin ? (
+        <input type='text' className='border-basic' />
+      ) : DUMMY.data.isMember ? (
+        <button>탈퇴</button>
+      ) : (
+        <button>가입</button>
+      )}
+    </main>
+  );
 };
 
 export default RecruitDetailPage;

--- a/src/pages/recruit/detail.tsx
+++ b/src/pages/recruit/detail.tsx
@@ -1,9 +1,7 @@
 import Image from 'next/image';
-import React, { ReactElement } from 'react';
+import React from 'react';
 
 import Avatar from '@/components/common/Avartar';
-import Layout from '@/layout/Layout';
-import RecruitLayout from '@/layout/RecruitLayout';
 import { NextPageWithLayout } from '@/types/layout';
 
 const DUMMY = {
@@ -19,6 +17,7 @@ const DUMMY = {
     notice: '공지입니다',
     isAdmin: false,
     isMember: true,
+    recruiting: true,
     admin: {
       userId: 1,
       nickname: '일이삼',
@@ -58,7 +57,7 @@ const RecruitDetailPage: NextPageWithLayout = () => {
         alt='모임 설명 이미지'
         priority
       />
-      <p>{DUMMY.data.endDate}</p>
+      <p>{DUMMY.data.recruiting ? '모집중' : '모집완료'}</p>
       <p>{DUMMY.data.online ? '온라인' : '오프라인'}</p>
       <p>{!DUMMY.data.online && DUMMY.data.location}</p>
       <p>{DUMMY.data.description}</p>

--- a/src/types/layout.ts
+++ b/src/types/layout.ts
@@ -1,0 +1,6 @@
+import { NextPage } from 'next';
+import { ReactElement, ReactNode } from 'react';
+
+export type NextPageWithLayout<P = object, IP = P> = NextPage<P, IP> & {
+  getLayout?: (page: ReactElement) => ReactNode;
+};


### PR DESCRIPTION
## 📌 이슈 번호

- close #72 <!-- 링크 달기 -->

## 👩‍💻 작업 내용

<!-- 자세히 쓰기 - 이미지가 필요한 경우 첨부하기, 영상도 ok -->
- 더미데이터를 활용하여 독서 모임 상세 페이지  구현
  -> 유저의 권한에 따라 보여지는 게 달라져요.
    - 참여하지 않는 경우: 가입 버튼 O  공지사항 X
    - 참여하는 경우: 탈퇴 버튼 O 공지사항 O
    - 모임장인 경우: 가입/탈퇴 버튼 X, 공지사항 O, 공지사항 입력창O
 
- 탭 관련해서 클릭 이벤트를 사용하는 곳에서 걸려고 하니까 조금 애매해져서 공통 컴포넌트 내에서 처리하도록 수정하였어요 담당자분 확인 부탁드립니다!
  -> 현재 탭의 경우 오른쪽 탭에서 새로고침을 하면 페이지는 유지되지만 탭이 왼쪽 탭으로 활성화되는 버그가 있어요! 참고 부탁드려요~

- 독서모임 상세페이지와 채팅페이지가 탭을 공통 레이아웃으로 갖도록 layout 관련 기능을 추가했습니다. `Layout.tsx`는 전체 공통 레이아웃 설정할 파일인데 아직 정해진 게 없어서 비워뒀어요!
   -> types 폴더에 layout 파일에 interface가 아니라 type을 사용했는데 해당 부분이 공식문서에 나와있는 부분이고 interface로 구현되기 어려운 부분인 것 같아서 일단 type으로 두었어요! 

- avatar는 공통컴포넌트를 사용했는데 모임 이미지는 next/Image를 사용했습니다. 그래서 임시로 도메인 추가해두었어요! 


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

<!-- 참고할 사항이 있다면 적어주세요 -->
