### PR TITLE
feat: 기존 액세스 토큰 유효기간 만료 시 새로운 액세스 토큰 발급

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,28 +1,42 @@
-import axios from 'axios';
+import axios, { InternalAxiosRequestConfig } from 'axios';
+
+import { setAxiosHeader } from '@/utils/helpers/axiosHandler';
+
+import { axiosInstance } from './axios';
 
 export const login = async (code: string) => {
   try {
-    // by 민형, 현재 토큰이 응답되지 않는 관계로 문제 해결 후 해당 소스코드로 수정_230509
-    // const data = await axios.get(
-    //   `http://mafiawithbooks.site/user/auth/kakao/?code=${code}`,
-    // );
+    const {
+      data: { accessToken },
+    } = await axios.get<{ accessToken: string }>(
+      `http://3.36.210.43:3000/user/auth/kakao?code=${code}`,
+    );
 
-    // by 민형, 임의의 액세스 토큰_230509
-    return 'sfasdf112sdfsadf111';
+    axiosInstance.defaults.headers['Authorization'] = `Bearer ${accessToken}`;
+
+    return accessToken;
   } catch {
     return null;
   }
 };
 
-export const silentRefresh = async () => {
+export const silentRefresh = async (
+  originRequest?: InternalAxiosRequestConfig,
+) => {
   try {
-    // by 민형, 현재 토큰이 응답되지 않는 관계로 문제 해결 후 해당 소스코드로 수정_230510
-    // const data = await axios.get(
-    //   `http://mafiawithbooks.site/user/auth/reissue`,
-    // );
+    const {
+      data: { accessToken },
+    } = await axiosInstance.request<{ accessToken: string }>({
+      method: 'GET',
+      url: `http://3.36.210.43:3000/user/auth/reissue`,
+    });
 
-    // by 민형, 임시로 null 설정_230510
-    return null;
+    if (originRequest) {
+      setAxiosHeader(originRequest, accessToken);
+      return axiosInstance(originRequest);
+    }
+
+    return accessToken;
   } catch {
     return null;
   }

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,0 +1,13 @@
+import axios, { CreateAxiosDefaults } from 'axios';
+
+const options: CreateAxiosDefaults = {
+  headers: {
+    'Accept': '*/*',
+    'Content-Type': 'application/json',
+  },
+  timeout: 3000,
+};
+
+export const axiosInstance = axios.create({
+  ...options,
+});

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,4 +1,6 @@
-import axios, { CreateAxiosDefaults } from 'axios';
+import axios, { AxiosError, CreateAxiosDefaults } from 'axios';
+
+import { silentRefresh } from './auth';
 
 const options: CreateAxiosDefaults = {
   headers: {
@@ -11,3 +13,20 @@ const options: CreateAxiosDefaults = {
 export const axiosInstance = axios.create({
   ...options,
 });
+
+const responseHandler = async (error: AxiosError) => {
+  const { config: originRequest, response } = error;
+
+  if (response) {
+    const { statusCode } = response.data as { statusCode: number };
+    console.warn(statusCode);
+
+    if (originRequest && statusCode === 401) {
+      return silentRefresh(originRequest);
+    }
+  }
+
+  return Promise.reject(error);
+};
+
+axiosInstance.interceptors.response.use(null, responseHandler);

--- a/src/pages/oauth/callback/kakao.tsx
+++ b/src/pages/oauth/callback/kakao.tsx
@@ -1,4 +1,5 @@
 import { useRouter } from 'next/router';
+import { useEffect } from 'react';
 import { useSetRecoilState } from 'recoil';
 
 import { login } from '@/api/auth';
@@ -24,13 +25,17 @@ const Kakao = () => {
     router.push('/');
   };
 
-  if (code && typeof code === 'string') {
-    loginKakao(code);
-  } else if (error === 'access_denied') {
-    // by 민형, 사용자가 로그인 페이지에서 취소한 경우_230509
-    router.push('/');
-  } else if (router.isReady) {
-    // by 민형, 사용자가 로그인 시 오류 발생_230509
+  useEffect(() => {
+    if (code && typeof code === 'string') loginKakao(code);
+  }, [code]);
+
+  // by 민형, 사용자가 로그인 페이지에서 취소한 경우_230509
+  useEffect(() => {
+    if (error === 'access_denied') router.push('/');
+  }, [error, router]);
+
+  // by 민형, 사용자 로그인 시 오류 발생_230509
+  if (router.isReady) {
     return (
       <>
         <h1>로그인에 실패했습니다</h1>

--- a/src/utils/helpers/axiosHandler.ts
+++ b/src/utils/helpers/axiosHandler.ts
@@ -1,0 +1,10 @@
+import { InternalAxiosRequestConfig } from 'axios';
+
+const setAxiosHeader = (
+  config: InternalAxiosRequestConfig,
+  acessToken: string,
+) => {
+  config.headers['Authorization'] = `Bearer ${acessToken}`;
+};
+
+export { setAxiosHeader };


### PR DESCRIPTION
## 📌 이슈 번호

- close #65 

## 👩‍💻 작업 내용

- 작업 내역은 commit 확인하시면 될 것 같습니다.
- 비 로그인 유저 => Bottom Nav Bar로 접근 시 모달 render, url로 접근시 main으로 redirect
![비-로그인-유저](https://github.com/dugeun-dugeun-project/frontend/assets/60873508/2564074c-d172-46f1-9edb-2478dc0d2823)
- 유저(토큰이 유효) => 데이터를 정상적으로 받아옴
![토큰이-유효](https://github.com/dugeun-dugeun-project/frontend/assets/60873508/1f20935d-ae45-4ce7-bb86-8b3b55164bd8)
- 유저(토큰이 만료) => 새로운 액세스 토큰을 받기 위한 요청을 함(해당 요청과 관련된 작업이 아직 백에서 완료되지 않아 새로운 토큰을 받지 못하고 있습니다)
![localhost_3000_book_record_bookid_1-Chrome-2023-05-28-12-20-07](https://github.com/dugeun-dugeun-project/frontend/assets/60873508/f6a8dc7d-7658-4a8f-9e54-53d6e2b2e63b)

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

<!-- 참고할 사항이 있다면 적어주세요 -->
- 영상의 메인에 Bottom Nav Bar 및 로그인 버튼은 기능 확인을 위해서 개발 환경에서 따로 추가한 것 입니다.. 해당 소스코드까지 commit 하는 것은 불 필요하다고 생각해 올리지 않았기 때문에 배포환경에서는 보이지 않을 겁니다.
- 궁금한 것 있으시면 질문해주세요~