### PR TITLE
feat: 독서 인원 모집 페이지 제작

### DIFF
--- a/src/components/common/ListItem/SearchResultListItem.tsx
+++ b/src/components/common/ListItem/SearchResultListItem.tsx
@@ -21,29 +21,31 @@ const SearchResultListItem = ({
   clickShiftPath,
 }: SearchResultListItemProps) => {
   return (
-    <Link
-      href={clickShiftPath === 'search' ? '/book/detail' : '/book/select'}
-      className='w-[100%] flex items-center bg-yellow-500 px-[20px] py-[15px] cursor-pointer'
-    >
-      <div className='w-[50%]'>
-        <BookImage
-          lazy={true}
-          src={src}
-          placeholder='스켈레톤'
-          alt='책 선택 리스트 아이템의 사진 입니다.'
-          size={imageSize}
-        />
-      </div>
-      <div className='w-[50%] flex flex-col font-bold text-[15px]'>
-        <span>{title}</span>
-        <span>{`${author[0]} ${author[1] ? `|  ${author[1]}` : ''}`}</span>
-        <span>{publisher}</span>
-      </div>
+    <>
+      <Link
+        href={clickShiftPath === 'search' ? '/book/detail' : '/book/select'}
+        className='w-[100%] flex items-center bg-yellow-500 px-[20px] py-[15px] cursor-pointer'
+      >
+        <div className='w-[50%]'>
+          <BookImage
+            lazy={true}
+            src={src}
+            placeholder='스켈레톤'
+            alt='책 선택 리스트 아이템의 사진 입니다.'
+            size={imageSize}
+          />
+        </div>
+        <div className='w-[50%] flex flex-col font-bold text-[15px]'>
+          <span>{title}</span>
+          <span>{`${author[0]} ${author[1] ? `|  ${author[1]}` : ''}`}</span>
+          <span>{publisher}</span>
+        </div>
+      </Link>
       {/* by 민형, 독서 인원 모집 리스트 아이템 클릭 시 상세 페이지로 이동하는 것을 확인하기 위한 임시 코드이므로 나중에 제거_230528 */}
       <Link href='/recruit/detail?recruitId=1' className='bg-white'>
         독서 상세페이지로
       </Link>
-    </Link>
+    </>
   );
 };
 

--- a/src/components/common/ListItem/SearchResultListItem.tsx
+++ b/src/components/common/ListItem/SearchResultListItem.tsx
@@ -39,6 +39,10 @@ const SearchResultListItem = ({
         <span>{`${author[0]} ${author[1] ? `|  ${author[1]}` : ''}`}</span>
         <span>{publisher}</span>
       </div>
+      {/* by 민형, 독서 인원 모집 리스트 아이템 클릭 시 상세 페이지로 이동하는 것을 확인하기 위한 임시 코드이므로 나중에 제거_230528 */}
+      <Link href='/recruit/detail?recruitId=1' className='bg-white'>
+        독서 상세페이지로
+      </Link>
     </Link>
   );
 };

--- a/src/components/recruit/RecruitInfinityScrollLists.tsx
+++ b/src/components/recruit/RecruitInfinityScrollLists.tsx
@@ -1,0 +1,65 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { useEffect, useState } from 'react';
+import { useInView } from 'react-intersection-observer';
+import tw from 'tailwind-styled-components';
+
+import { getBookSearchResultData } from '@/api/book';
+
+import SearchResultList from '../book/search/SearchResultList';
+
+const RecruitInfinityScrollLists = () => {
+  const { ref, inView } = useInView();
+  const [page, setPage] = useState(2);
+
+  const {
+    data: bookSearchResultLists,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    status,
+  } = useInfiniteQuery(
+    ['reading', 'personnel', 'recruit'],
+    ({ pageParam }) => getBookSearchResultData('미움 받을 용기', pageParam),
+    {
+      onSuccess: () => setPage((prev) => prev + 1),
+      onError: (error) => console.error(error),
+      getNextPageParam: (lastPage) => {
+        if (lastPage.is_end) return;
+
+        return page;
+      },
+    },
+  );
+
+  useEffect(() => {
+    if (inView) fetchNextPage();
+  }, [fetchNextPage, inView]);
+
+  return (
+    <Container>
+      {status === 'success' && (
+        <>
+          {bookSearchResultLists.pages.map(
+            ({ documents }, index) =>
+              documents.length > 0 &&
+              documents[index] && (
+                <SearchResultList
+                  key={documents[index].isbn}
+                  listData={documents}
+                />
+              ),
+          )}
+          <Bottom ref={ref}>
+            {isFetchingNextPage && hasNextPage && 'Loading...'}
+          </Bottom>
+        </>
+      )}
+    </Container>
+  );
+};
+
+export default RecruitInfinityScrollLists;
+
+const Container = tw.div``;
+
+const Bottom = tw.div``;

--- a/src/components/recruit/RecruitInfinityScrollLists.tsx
+++ b/src/components/recruit/RecruitInfinityScrollLists.tsx
@@ -28,6 +28,7 @@ const RecruitInfinityScrollLists = () => {
 
         return page;
       },
+      staleTime: 20000,
     },
   );
 

--- a/src/pages/recruit/index.tsx
+++ b/src/pages/recruit/index.tsx
@@ -1,4 +1,5 @@
 import { useInfiniteQuery } from '@tanstack/react-query';
+import Link from 'next/link';
 import React, { useEffect, useState } from 'react';
 import { useInView } from 'react-intersection-observer';
 import tw from 'tailwind-styled-components';
@@ -35,26 +36,31 @@ const RecruitPage = () => {
   }, [fetchNextPage, inView]);
 
   return (
-    <Container>
-      <h1>독서 인원 모집 페이지</h1>
-      {status === 'success' && (
-        <>
-          {bookSearchResultLists.pages.map(
-            ({ documents }, index) =>
-              documents.length > 0 &&
-              documents[index] && (
-                <SearchResultList
-                  key={documents[index].isbn}
-                  listData={documents}
-                />
-              ),
-          )}
-          <Bottom ref={ref}>
-            {isFetchingNextPage && hasNextPage && 'Loading...'}
-          </Bottom>
-        </>
-      )}
-    </Container>
+    <>
+      <Container>
+        <h1>독서 인원 모집 페이지</h1>
+        {status === 'success' && (
+          <>
+            {bookSearchResultLists.pages.map(
+              ({ documents }, index) =>
+                documents.length > 0 &&
+                documents[index] && (
+                  <SearchResultList
+                    key={documents[index].isbn}
+                    listData={documents}
+                  />
+                ),
+            )}
+            <Bottom ref={ref}>
+              {isFetchingNextPage && hasNextPage && 'Loading...'}
+            </Bottom>
+          </>
+        )}
+      </Container>
+      <PersonnelRecruitButton href='/recruit/write'>
+        독서 인원 모집 글 작성
+      </PersonnelRecruitButton>
+    </>
   );
 };
 
@@ -63,3 +69,12 @@ export default RecruitPage;
 const Container = tw.div``;
 
 const Bottom = tw.div``;
+
+const PersonnelRecruitButton = tw(Link)`
+  fixed
+  bottom-0
+  right-0
+  w-full
+  bg-blue-500
+  text-center
+`;

--- a/src/pages/recruit/index.tsx
+++ b/src/pages/recruit/index.tsx
@@ -1,62 +1,20 @@
-import { useInfiniteQuery } from '@tanstack/react-query';
 import Link from 'next/link';
-import React, { useEffect, useState } from 'react';
-import { useInView } from 'react-intersection-observer';
+import { useEffect, useState } from 'react';
 import tw from 'tailwind-styled-components';
 
-import { getBookSearchResultData } from '@/api/book';
-import SearchResultList from '@/components/book/search/SearchResultList';
+import RecruitInfinityScrollLists from '@/components/recruit/RecruitInfinityScrollLists';
 
 const RecruitPage = () => {
-  const { ref, inView } = useInView();
-  const [page, setPage] = useState(1);
-
-  const {
-    data: bookSearchResultLists,
-    fetchNextPage,
-    hasNextPage,
-    isFetchingNextPage,
-    status,
-  } = useInfiniteQuery(
-    ['reading', 'personnel', 'recruit'],
-    ({ pageParam = 1 }) => getBookSearchResultData('미움 받을 용기', pageParam),
-    {
-      onSuccess: () => setPage((prev) => prev + 1),
-      onError: (error) => console.error(error),
-      getNextPageParam: (lastPage) => {
-        if (lastPage.is_end) return;
-
-        return page;
-      },
-    },
-  );
+  const [isMounted, setIsMounted] = useState(false);
 
   useEffect(() => {
-    if (inView) fetchNextPage();
-  }, [fetchNextPage, inView]);
+    setIsMounted(true);
+  }, []);
 
   return (
     <>
-      <Container>
-        <h1>독서 인원 모집 페이지</h1>
-        {status === 'success' && (
-          <>
-            {bookSearchResultLists.pages.map(
-              ({ documents }, index) =>
-                documents.length > 0 &&
-                documents[index] && (
-                  <SearchResultList
-                    key={documents[index].isbn}
-                    listData={documents}
-                  />
-                ),
-            )}
-            <Bottom ref={ref}>
-              {isFetchingNextPage && hasNextPage && 'Loading...'}
-            </Bottom>
-          </>
-        )}
-      </Container>
+      <h1>독서 인원 모집 페이지</h1>
+      {isMounted && <RecruitInfinityScrollLists />}
       <PersonnelRecruitButton href='/recruit/write'>
         독서 인원 모집 글 작성
       </PersonnelRecruitButton>
@@ -65,10 +23,6 @@ const RecruitPage = () => {
 };
 
 export default RecruitPage;
-
-const Container = tw.div``;
-
-const Bottom = tw.div``;
 
 const PersonnelRecruitButton = tw(Link)`
   fixed

--- a/src/pages/recruit/index.tsx
+++ b/src/pages/recruit/index.tsx
@@ -1,7 +1,10 @@
+import { dehydrate, QueryClient } from '@tanstack/react-query';
+import { GetServerSideProps } from 'next';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import tw from 'tailwind-styled-components';
 
+import { getBookSearchResultData } from '@/api/book';
 import RecruitInfinityScrollLists from '@/components/recruit/RecruitInfinityScrollLists';
 
 const RecruitPage = () => {
@@ -32,3 +35,18 @@ const PersonnelRecruitButton = tw(Link)`
   bg-blue-500
   text-center
 `;
+
+export const getServerSideProps: GetServerSideProps = async () => {
+  const queryClient = new QueryClient();
+
+  await queryClient.prefetchInfiniteQuery(
+    ['reading', 'personnel', 'recruit'],
+    () => getBookSearchResultData('미움 받을 용기', 1),
+  );
+
+  return {
+    props: {
+      dehydratedState: JSON.parse(JSON.stringify(dehydrate(queryClient))),
+    },
+  };
+};

--- a/src/pages/recruit/index.tsx
+++ b/src/pages/recruit/index.tsx
@@ -1,7 +1,65 @@
-import React from 'react';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import React, { useEffect, useState } from 'react';
+import { useInView } from 'react-intersection-observer';
+import tw from 'tailwind-styled-components';
+
+import { getBookSearchResultData } from '@/api/book';
+import SearchResultList from '@/components/book/search/SearchResultList';
 
 const RecruitPage = () => {
-  return <div>독서 인원 모집 페이지</div>;
+  const { ref, inView } = useInView();
+  const [page, setPage] = useState(1);
+
+  const {
+    data: bookSearchResultLists,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    status,
+  } = useInfiniteQuery(
+    ['reading', 'personnel', 'recruit'],
+    ({ pageParam = 1 }) => getBookSearchResultData('미움 받을 용기', pageParam),
+    {
+      onSuccess: () => setPage((prev) => prev + 1),
+      onError: (error) => console.error(error),
+      getNextPageParam: (lastPage) => {
+        if (lastPage.is_end) return;
+
+        return page;
+      },
+    },
+  );
+
+  useEffect(() => {
+    if (inView) fetchNextPage();
+  }, [fetchNextPage, inView]);
+
+  return (
+    <Container>
+      <h1>독서 인원 모집 페이지</h1>
+      {status === 'success' && (
+        <>
+          {bookSearchResultLists.pages.map(
+            ({ documents }, index) =>
+              documents.length > 0 &&
+              documents[index] && (
+                <SearchResultList
+                  key={documents[index].isbn}
+                  listData={documents}
+                />
+              ),
+          )}
+          <Bottom ref={ref}>
+            {isFetchingNextPage && hasNextPage && 'Loading...'}
+          </Bottom>
+        </>
+      )}
+    </Container>
+  );
 };
 
 export default RecruitPage;
+
+const Container = tw.div``;
+
+const Bottom = tw.div``;


### PR DESCRIPTION
## 📌 이슈 번호

- close #91 

## 👩‍💻 작업 내용

- 작업 내역은 commit을 통해 확인하시면 됩니다~
- TanStack Query, getServerSideProps를 통해 특정 key 값을 가지고 있는 query에 데이터 pre-fetch
- 아래 사진 같은 경우 pages의 도서 리스트 데이터가 4개인데 1개는 pre-fetch 했으므로 API 호출은 3번만 합니다.
- 데이터 4개
![데이터 4개](https://github.com/dugeun-dugeun-project/frontend/assets/60873508/0c187011-1f4f-42ff-b13c-696e544fdfe0)
- API 호출은 3번만
![API 호출 3번](https://github.com/dugeun-dugeun-project/frontend/assets/60873508/953ce357-d2f5-4dea-a324-f19201db23af)


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

- 현재 독서 인원 모집 리스트 데이터가 없기도하고 레이아웃을 잡기 위해 카카오 도서 검색 API 사용했습니다.
- pre-fetch를 하다보니 Hydration Error가 발생해 useEffect를 통해 컴포넌트가 mount 됬을 때 리스트를 render 해줌으로써 문제를 해결 했습니다
- Hydration Error => pre-rendering된 React 트리와 브라우저에서 첫번째 렌더링하는 동안 렌더링된 React 트리 사이의 차이가 발생하기 때문에 나는 오류
- stale time을 설정하지 않으면 pre-fetch한 캐싱 값을 사용하지 못하므로 넉넉하게 20초로 설정해두었습니다.
- 참고 자료 => https://velog.io/@dee0518/Next.js-react-hydration-error