### PR TITLE
feat: 독서 모임 상세 페이지 api 연결

### DIFF
--- a/src/api/recruit.ts
+++ b/src/api/recruit.ts
@@ -31,3 +31,16 @@ export const postReadingClassOpen = async (
     throw new Error('모임 추가 작업 중 에러가 발생하였습니다.');
   }
 };
+
+export const getReadingGroupInfo = async (groupId: string) => {
+  try {
+    const response = await axiosInstance.request({
+      method: 'GET',
+      url: `${BASE_URL}/groups/${groupId}`,
+    });
+
+    if (response) return response.data;
+  } catch (error) {
+    console.error(error);
+  }
+};


### PR DESCRIPTION
## 📌 이슈 번호

- close #151  <!-- 링크 달기 -->

## 👩‍💻 작업 내용

<!-- 자세히 쓰기 - 이미지가 필요한 경우 첨부하기, 영상도 ok -->
- `getServerSideProps`를 통해서 groupId로 query를 받아서 fetch를 합니다!
- 아직 그룹 api에서 모임장, 멤버 여부, 모임장 id, 유저 리스트가 아직 안 들어오는 상황이어서 해당 필드를 사용하는 부분은 dummy 데이터를 사용하게 두어서 dummy 데이터를 남겨두었고 백엔드에서 완성되면 다시 수정할 예정입니다! 


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

<!-- 참고할 사항이 있다면 적어주세요 -->
