### PR TITLE
feat: 독서 모임 상세페이지 모임장 권한 구현

### DIFF
--- a/src/api/main.ts
+++ b/src/api/main.ts
@@ -1,13 +1,11 @@
 import { axiosInstance } from './axios';
 
-const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;
-
 //인기모임 조회
 export const fetchBestGroup = async () => {
   try {
     const response = await axiosInstance.request({
       method: 'GET',
-      url: `${BASE_URL}/groups/top/3`,
+      url: `/groups/top/3`,
     });
 
     if (response) return response.data;
@@ -21,7 +19,7 @@ export const fetchReadingGroupLeader = async (groupId: number | string) => {
   try {
     const response = await axiosInstance.request({
       method: 'GET',
-      url: `${BASE_URL}/groups/${groupId}/group_lead`,
+      url: `/groups/${groupId}/group_lead`,
     });
 
     if (response) return response.data;
@@ -35,7 +33,7 @@ export const fetchRecord = async (lastId: number) => {
   try {
     const response = await axiosInstance.request({
       method: 'GET',
-      url: `${BASE_URL}/records?&lastId=${lastId}&pageSize=5`,
+      url: `/records?&lastId=${lastId}&pageSize=5`,
     });
 
     if (response) return response.data;

--- a/src/api/recruit.ts
+++ b/src/api/recruit.ts
@@ -1,8 +1,9 @@
-import { GroupLists } from '@/types/recruit';
+import { GroupList, GroupLists } from '@/types/recruit';
 import { ClassOpenStateObjProps } from '@/types/recruit';
 
 import { axiosInstance } from './axios';
 
+//독서모임 리스트 조회
 export const getReadingClassData = async (
   page: number,
 ): Promise<GroupLists> => {
@@ -22,6 +23,7 @@ export const getReadingClassData = async (
   }
 };
 
+//독서모임 개설
 export const postReadingClassOpen = async (
   openReadingClassData: ClassOpenStateObjProps,
 ) => {
@@ -50,6 +52,7 @@ export const postReadingClassOpen = async (
   }
 };
 
+//독서모임 정보 상세 조회
 export const fetchReadingGroupInfo = async (groupId: string) => {
   try {
     const response = await axiosInstance.request({
@@ -63,6 +66,7 @@ export const fetchReadingGroupInfo = async (groupId: string) => {
   }
 };
 
+//독서모임 가입
 export const postGroupJoinUser = async (groupId: number) => {
   try {
     await axiosInstance.request({
@@ -74,11 +78,33 @@ export const postGroupJoinUser = async (groupId: number) => {
   }
 };
 
+//독서모임 탈퇴
 export const postGroupLeaveUser = async (groupId: number) => {
   try {
     await axiosInstance.request({
       method: 'POST',
       url: `/groups/user/${groupId}/leave`,
+    });
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+interface patchReadingClassChangeType {
+  groupId: number;
+  groupData: Partial<GroupList>;
+}
+
+//독서모임 수정 patch api
+export const patchReadingClassChange = async ({
+  groupId,
+  groupData,
+}: patchReadingClassChangeType) => {
+  try {
+    await axiosInstance.request({
+      method: 'PATCH',
+      url: `/groups/${groupId}`,
+      data: groupData,
     });
   } catch (error) {
     console.error(error);

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -14,7 +14,7 @@ const Header = ({ title, moreMenu, className }: Props) => {
   return (
     <div
       className={`flex items-center justify-between w-full max-w-xl px-5 h-14 ${
-        className ? className : ''
+        className ?? ''
       }`}
     >
       <div className='flex-1'>

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -5,13 +5,18 @@ import { ReactNode } from 'react';
 interface Props {
   title?: string;
   moreMenu?: ReactNode;
+  className?: string;
 }
 
-const Header = ({ title, moreMenu }: Props) => {
+const Header = ({ title, moreMenu, className }: Props) => {
   const router = useRouter();
 
   return (
-    <div className='flex items-center justify-between w-full px-5 h-14'>
+    <div
+      className={`flex items-center justify-between w-full max-w-xl px-5 h-14 ${
+        className ? className : ''
+      }`}
+    >
       <div className='flex-1'>
         <Image
           onClick={() => router.back()}
@@ -23,7 +28,7 @@ const Header = ({ title, moreMenu }: Props) => {
         />
       </div>
       <div className='text-xl text-center flex-[4_4_0%]'>{title}</div>
-      <div className='flex-1'>{moreMenu && moreMenu}</div>
+      <div className='flex-1 text-right'>{moreMenu && moreMenu}</div>
       {/**수정버튼 등 오른쪽 메뉴 추가 */}
     </div>
   );

--- a/src/components/recruit/detail/RecruitParticipationControl.tsx
+++ b/src/components/recruit/detail/RecruitParticipationControl.tsx
@@ -1,4 +1,4 @@
-import { QueryClient, useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import React from 'react';
 import { useRecoilState } from 'recoil';
 
@@ -20,7 +20,7 @@ const RecruitUserManagement = ({
   recruitmentStatus,
 }: RecruitManagementProps) => {
   const [modal, setModal] = useRecoilState(modalStateAtom);
-  const queryClient = new QueryClient();
+  const queryClient = useQueryClient();
   const { mutate: joinGroupUser } = useMutation(postGroupJoinUser, {
     onSuccess: () => {
       setModal({ type: 'HIDDEN' });

--- a/src/components/recruit/detail/RecruitStatusSelectModal.tsx
+++ b/src/components/recruit/detail/RecruitStatusSelectModal.tsx
@@ -1,0 +1,132 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import React, { useEffect, useState } from 'react';
+import ReactDOM from 'react-dom';
+import { useSetRecoilState } from 'recoil';
+
+import { patchReadingClassChange } from '@/api/recruit';
+import { selectRecruitStatusAtom } from '@/recoil/modal';
+
+interface RecruitmentModalType {
+  groupId: number;
+  recruitmentStatus: boolean;
+}
+
+const BackDrop = () => {
+  const setModal = useSetRecoilState(selectRecruitStatusAtom);
+  return (
+    <div
+      className='fixed w-full max-w-xl h-screen z-20 bg-[rgba(0,0,0,0.6)] top-0 mx-auto'
+      onClick={() => setModal(false)}
+    />
+  );
+};
+
+const ModalOverlay = ({ groupId, recruitmentStatus }: RecruitmentModalType) => {
+  const setModal = useSetRecoilState(selectRecruitStatusAtom);
+  const queryClient = useQueryClient();
+
+  const { mutate: updateRecruitmentStatus } = useMutation(
+    patchReadingClassChange,
+    {
+      onSuccess: () => {
+        setModal(false);
+        return queryClient.invalidateQueries([
+          'recruitDetail',
+          String(groupId),
+        ]);
+      },
+    },
+  );
+
+  const handleChangeRecruitmentStatus = (
+    groupId: number,
+    recruitmentStatus: boolean,
+  ) => {
+    updateRecruitmentStatus({
+      groupId,
+      groupData: {
+        recruitment_status: !recruitmentStatus,
+      },
+    });
+  };
+
+  const recruitmentStatusList = [
+    {
+      type: true,
+      title: '모집중',
+    },
+    {
+      type: false,
+      title: '모집완료',
+    },
+  ];
+
+  const handleChangeRecruitmentStatusTitle = (
+    groupId: number,
+    recruitmentStatus: boolean,
+  ) => {
+    return recruitmentStatusList.map(({ type, title }) => (
+      <button
+        key={title}
+        onClick={() =>
+          handleChangeRecruitmentStatus(groupId, recruitmentStatus)
+        }
+        className={`flex justify-center items-center h-14 w-full text-lg ${
+          recruitmentStatus === type ? 'text-[#67A68A]' : 'text-black'
+        }`}
+      >
+        {title}
+      </button>
+    ));
+  };
+
+  return (
+    <>
+      <div className='fixed left-0 right-0 w-5/6 max-w-lg bg-[#F3F3F3] h-40 z-30 rounded-2xl bottom-24 animate-slideUp mx-auto'>
+        <div className='flex flex-col justify-center items-center divide-y'>
+          <p className='h-11 flex justify-center items-center text-[#707070] text-sm'>
+            상태 변경
+          </p>
+          {handleChangeRecruitmentStatusTitle(groupId, recruitmentStatus)}
+        </div>
+      </div>
+      <button
+        onClick={() => setModal(false)}
+        className='fixed left-0 right-0 w-5/6 max-w-lg bg-white h-14 z-30 rounded-2xl bottom-8 mx-auto text-lg text-[#67A68A] animate-slideUp'
+      >
+        닫기
+      </button>
+    </>
+  );
+};
+
+const RecruitStatusSelectModal = ({
+  groupId,
+  recruitmentStatus,
+}: RecruitmentModalType) => {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+
+    return () => setMounted(false);
+  }, []);
+
+  const element =
+    typeof window !== 'undefined' && document.getElementById('portal');
+
+  return mounted && element ? (
+    <>
+      {ReactDOM.createPortal(<BackDrop />, element)}
+      {ReactDOM.createPortal(
+        <ModalOverlay
+          recruitmentStatus={recruitmentStatus}
+          groupId={groupId}
+        />,
+        element,
+      )}
+    </>
+  ) : null;
+};
+
+export default RecruitStatusSelectModal;

--- a/src/components/recruit/detail/RecruitStatusSelectModal.tsx
+++ b/src/components/recruit/detail/RecruitStatusSelectModal.tsx
@@ -41,7 +41,10 @@ const ModalOverlay = ({ groupId, recruitmentStatus }: RecruitmentModalType) => {
   const handleChangeRecruitmentStatus = (
     groupId: number,
     recruitmentStatus: boolean,
+    type: boolean,
   ) => {
+    if (type === recruitmentStatus) return;
+
     updateRecruitmentStatus({
       groupId,
       groupData: {
@@ -61,7 +64,7 @@ const ModalOverlay = ({ groupId, recruitmentStatus }: RecruitmentModalType) => {
     },
   ];
 
-  const handleChangeRecruitmentStatusTitle = (
+  const changeRecruitmentStatusComponent = (
     groupId: number,
     recruitmentStatus: boolean,
   ) => {
@@ -69,7 +72,7 @@ const ModalOverlay = ({ groupId, recruitmentStatus }: RecruitmentModalType) => {
       <button
         key={title}
         onClick={() =>
-          handleChangeRecruitmentStatus(groupId, recruitmentStatus)
+          handleChangeRecruitmentStatus(groupId, recruitmentStatus, type)
         }
         className={`flex justify-center items-center h-14 w-full text-lg ${
           recruitmentStatus === type ? 'text-[#67A68A]' : 'text-black'
@@ -87,7 +90,7 @@ const ModalOverlay = ({ groupId, recruitmentStatus }: RecruitmentModalType) => {
           <p className='h-11 flex justify-center items-center text-[#707070] text-sm'>
             상태 변경
           </p>
-          {handleChangeRecruitmentStatusTitle(groupId, recruitmentStatus)}
+          {changeRecruitmentStatusComponent(groupId, recruitmentStatus)}
         </div>
       </div>
       <button

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,6 @@
 import { dehydrate, QueryClient } from '@tanstack/react-query';
 import { GetServerSideProps } from 'next';
+import { useEffect, useState } from 'react';
 
 import { fetchBestGroup } from '@/api/main';
 import BookShelfPreview from '@/components/common/BookShelfPreview';
@@ -23,6 +24,14 @@ export default function Home({
 }: {
   bestGroup: BestGroupListType[];
 }) {
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    setHydrated(true);
+  }, []);
+
+  if (!hydrated) return null;
+
   return (
     <main>
       <section className='bg-[#C6BDA4] h-[17.125rem]'>

--- a/src/pages/recruit/detail/index.tsx
+++ b/src/pages/recruit/detail/index.tsx
@@ -34,7 +34,7 @@ const RecruitDetailPage = () => {
     isLoading: isGroupLoading,
   } = useQuery<ReadingGroupType>(
     ['recruitDetail', groupId],
-    async () => await fetchReadingGroupInfo(groupId as string),
+    () => fetchReadingGroupInfo(groupId as string),
     {
       staleTime: 1000,
     },

--- a/src/recoil/modal.ts
+++ b/src/recoil/modal.ts
@@ -13,3 +13,8 @@ export const selectModalStateAtom = atom<boolean>({
   key: 'selectModalState',
   default: false,
 });
+
+export const selectRecruitStatusAtom = atom<boolean>({
+  key: 'selectRecruitStatus',
+  default: false,
+});


### PR DESCRIPTION
## 📌 이슈 번호

- close #148  <!-- 링크 달기 -->

## 👩‍💻 작업 내용

<!-- 자세히 쓰기 - 이미지가 필요한 경우 첨부하기, 영상도 ok -->
- 독서모임 상세페이지에서 모임장 권한에 따라 추가하였습니다.
1. 상세페이지에서 모집여부 변경 가능
2. 모임 수정 페이지로 이동 가능
  - 아직 해당 페이지가 없어서 주소는 비워뒀습니다.

- Header 컴포넌트에서 추가 스타일 적용할 수 있도록 수정하였습니다!
- 멤버 강퇴 기능은 아직 서버에서 userGroup이 제대로 들어오지 않아서 해당 부분 적용되면 구현할 예정입니다!
- 아이콘은 다 임시로 넣어둔 거예요! 시온님께서 파일 전달해주시면 그 때 다시 적용하겠습니다!

<img src='https://github.com/dugeun-dugeun-project/frontend/assets/107309247/9c4b8579-a4ca-480f-bc9b-2e074b345569' width=500 />
모집 여부 변경 모달 이미지


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

<!-- 참고할 사항이 있다면 적어주세요 -->
