### PR TITLE
feat: 독서 모임 수정 페이지

### DIFF
--- a/src/api/recruit.ts
+++ b/src/api/recruit.ts
@@ -78,16 +78,24 @@ export const postReadingClassOpen = async (
 };
 
 //독서모임 정보 상세 조회
-export const fetchReadingGroupInfo = async (groupId: string) => {
+export const fetchReadingGroupInfo = async (
+  groupId: string,
+): Promise<GroupList> => {
   try {
-    const response = await axiosInstance.request({
+    const {
+      data: { group: groupDataObj },
+    } = await axiosInstance.request({
       method: 'GET',
       url: `/groups/${groupId}`,
     });
 
-    if (response) return response.data;
+    if (groupDataObj) {
+      return groupDataObj;
+    } else {
+      throw new Error('독서 모임 상세 데이터를 찾을 수 없습니다.');
+    }
   } catch (error) {
-    console.error(error);
+    throw new Error('독서 모임 상세 데이터 fetch 시 문제가 발생하였습니다.');
   }
 };
 

--- a/src/api/recruit.ts
+++ b/src/api/recruit.ts
@@ -125,7 +125,7 @@ export const postGroupLeaveUser = async (groupId: number) => {
 
 interface patchReadingClassChangeType {
   groupId: number;
-  groupData: Partial<GroupList>;
+  groupData: Partial<GroupList> | GroupFormStateObjProps;
 }
 
 //독서모임 수정 patch api

--- a/src/api/recruit.ts
+++ b/src/api/recruit.ts
@@ -1,5 +1,5 @@
 import { GroupList, GroupLists } from '@/types/recruit';
-import { ClassOpenStateObjProps } from '@/types/recruit';
+import { GroupFormStateObjProps } from '@/types/recruit';
 
 import { axiosInstance } from './axios';
 
@@ -50,7 +50,7 @@ export const getReadingClassData = async (
 
 //독서모임 개설
 export const postReadingClassOpen = async (
-  openReadingClassData: ClassOpenStateObjProps,
+  openReadingClassData: GroupFormStateObjProps,
 ) => {
   const body = {
     name: openReadingClassData.className,

--- a/src/components/recruit/RecruitForm.tsx
+++ b/src/components/recruit/RecruitForm.tsx
@@ -1,0 +1,100 @@
+import tw from 'tailwind-styled-components';
+
+import {
+  GroupFormChangeStateObjProps,
+  GroupFormStateObjProps,
+} from '@/types/recruit';
+
+import AuthRequiredPage from '../auth/AuthRequiredPage';
+import Header from '../common/Header';
+import RecruitFormUserInput from './RecruitFormUserInput';
+
+interface RecruitFormProps {
+  classStateObj: GroupFormStateObjProps;
+  classChangeStateObj: GroupFormChangeStateObjProps;
+  onClickButton: () => void;
+  type: string;
+}
+
+const RecruitForm = ({
+  classStateObj,
+  classChangeStateObj,
+  onClickButton,
+  type,
+}: RecruitFormProps) => {
+  return (
+    <AuthRequiredPage>
+      <Container>
+        <Header />
+        <Wrapper>
+          <PageDescription>
+            {type === '개설' ? (
+              <>
+                모임 만들기
+                <br />
+                독서 모임을 개설해 볼까요?
+              </>
+            ) : (
+              '모임 수정'
+            )}
+          </PageDescription>
+          <RecruitFormWrapper>
+            <RecruitFormUserInput
+              classStateObj={classStateObj}
+              classChangeStateObj={classChangeStateObj}
+            />
+          </RecruitFormWrapper>
+        </Wrapper>
+        <ClassButtonWrap>
+          <ClassButton onClick={onClickButton}>
+            {type === '개설' ? '만들기' : '수정하기'}
+          </ClassButton>
+        </ClassButtonWrap>
+      </Container>
+    </AuthRequiredPage>
+  );
+};
+
+export default RecruitForm;
+
+const Container = tw.div`
+  h-full
+  bg-white
+`;
+
+const Wrapper = tw.div`
+  px-[5%]
+  mx-auto
+  bg-white
+`;
+
+const PageDescription = tw.h1`
+  text-xl
+  font-bold
+  mt-[10px]
+  mb-[20px]
+`;
+
+const RecruitFormWrapper = tw.div`
+  flex
+  flex-col
+`;
+
+const ClassButtonWrap = tw.div`  
+  border 
+  border-t-[black]
+  border-opacity-10
+  w-full
+  px-[15px]
+  py-[12.5px]
+  bg-white
+`;
+
+const ClassButton = tw.button`  
+  bg-[#67A68A]
+  w-full
+  h-[55px]
+  text-white
+  rounded
+  font-bold
+`;

--- a/src/components/recruit/RecruitFormUserInput.tsx
+++ b/src/components/recruit/RecruitFormUserInput.tsx
@@ -8,15 +8,15 @@ import {
   GroupFormStateObjProps,
 } from '@/types/recruit';
 
-interface RecruitOpenFormProps {
+interface RecruitFormUserInputProps {
   classStateObj: GroupFormStateObjProps;
   classChangeStateObj: GroupFormChangeStateObjProps;
 }
 
-const RecruitOpenForm = ({
+const RecruitFormUserInput = ({
   classStateObj,
   classChangeStateObj,
-}: RecruitOpenFormProps) => {
+}: RecruitFormUserInputProps) => {
   const [openRegionStatus, setOpenRegionStatus] = useState('hidden');
   const [openDayStatus, setOpenDayStatus] = useState('hidden');
   const [openTimeStatus, setOpenTimeStatus] = useState('hidden');
@@ -185,7 +185,7 @@ const RecruitOpenForm = ({
   );
 };
 
-export default RecruitOpenForm;
+export default RecruitFormUserInput;
 
 const Container = tw.div`
 `;

--- a/src/components/recruit/RecruitOpenForm.tsx
+++ b/src/components/recruit/RecruitOpenForm.tsx
@@ -4,13 +4,13 @@ import tw from 'tailwind-styled-components';
 
 import { DAY_DATA, REGION_DATA, TIME_DATA } from '@/constants/recruit';
 import {
-  ClassOpenChangeStateObjProps,
-  ClassOpenStateObjProps,
+  GroupFormChangeStateObjProps,
+  GroupFormStateObjProps,
 } from '@/types/recruit';
 
 interface RecruitOpenFormProps {
-  classStateObj: ClassOpenStateObjProps;
-  classChangeStateObj: ClassOpenChangeStateObjProps;
+  classStateObj: GroupFormStateObjProps;
+  classChangeStateObj: GroupFormChangeStateObjProps;
 }
 
 const RecruitOpenForm = ({

--- a/src/hooks/useGroupForm.ts
+++ b/src/hooks/useGroupForm.ts
@@ -1,11 +1,11 @@
 import { useState } from 'react';
 
 import {
-  ClassOpenChangeStateObjProps,
-  ClassOpenStateObjProps,
+  GroupFormChangeStateObjProps,
+  GroupFormStateObjProps,
 } from '@/types/recruit';
 
-export const useGroupForm = (classData: ClassOpenStateObjProps) => {
+export const useGroupForm = (classData: GroupFormStateObjProps) => {
   const {
     className: relayedClassName,
     classType: relayedClassType,
@@ -30,7 +30,7 @@ export const useGroupForm = (classData: ClassOpenStateObjProps) => {
   );
   const [classKakaoLink, setClassKakaoLink] = useState(relayedClassKakaoLink);
 
-  const classStateObj: ClassOpenStateObjProps = {
+  const classStateObj: GroupFormStateObjProps = {
     className,
     classType,
     classRegion,
@@ -41,7 +41,7 @@ export const useGroupForm = (classData: ClassOpenStateObjProps) => {
     classKakaoLink,
   };
 
-  const classChangeStateObj: ClassOpenChangeStateObjProps = {
+  const classChangeStateObj: GroupFormChangeStateObjProps = {
     changeClassName: (e) => {
       setClassName(e.target.value);
     },

--- a/src/hooks/useGroupForm.ts
+++ b/src/hooks/useGroupForm.ts
@@ -1,0 +1,76 @@
+import { useState } from 'react';
+
+import {
+  ClassOpenChangeStateObjProps,
+  ClassOpenStateObjProps,
+} from '@/types/recruit';
+
+export const useGroupForm = (classData: ClassOpenStateObjProps) => {
+  const {
+    className: relayedClassName,
+    classType: relayedClassType,
+    classRegion: relayedClassRegion,
+    classDescription: relayedClassDescription,
+    classDay: relayedClassDay,
+    classTime: relayedClassTime,
+    classPeopleNumber: relayedClassPeopleNumber,
+    classKakaoLink: relayedClassKakaoLink,
+  } = classData;
+
+  const [className, setClassName] = useState(relayedClassName);
+  const [classType, setClassType] = useState(relayedClassType);
+  const [classRegion, setClassRegion] = useState(relayedClassRegion);
+  const [classDescription, setClassDescription] = useState(
+    relayedClassDescription,
+  );
+  const [classDay, setClassDay] = useState(relayedClassDay);
+  const [classTime, setClassTime] = useState(relayedClassTime);
+  const [classPeopleNumber, setClassPeopleNumber] = useState(
+    relayedClassPeopleNumber,
+  );
+  const [classKakaoLink, setClassKakaoLink] = useState(relayedClassKakaoLink);
+
+  const classStateObj: ClassOpenStateObjProps = {
+    className,
+    classType,
+    classRegion,
+    classDescription,
+    classDay,
+    classTime,
+    classPeopleNumber,
+    classKakaoLink,
+  };
+
+  const classChangeStateObj: ClassOpenChangeStateObjProps = {
+    changeClassName: (e) => {
+      setClassName(e.target.value);
+    },
+    changeClassType: (type) => {
+      if (type === 'online') setClassType('online');
+      else setClassType('offline');
+    },
+    changeClassRegion: (e) => {
+      const selectedItem = e.target as HTMLUListElement;
+      selectedItem.textContent && setClassRegion(selectedItem.textContent);
+    },
+    changeClassDescription: (e) => {
+      setClassDescription(e.target.value);
+    },
+    changeClassDay: (e) => {
+      const selectedItem = e.target as HTMLUListElement;
+      selectedItem.textContent && setClassDay(selectedItem.textContent);
+    },
+    changeClassTime: (e) => {
+      const selectedItem = e.target as HTMLUListElement;
+      selectedItem.textContent && setClassTime(selectedItem.textContent);
+    },
+    changeClassPeopleNumber: (e) => {
+      setClassPeopleNumber(e.target.value);
+    },
+    changeClassKakaoLink: (e) => {
+      setClassKakaoLink(e.target.value);
+    },
+  };
+
+  return { classStateObj, classChangeStateObj } as const;
+};

--- a/src/pages/recruit/detail/index.tsx
+++ b/src/pages/recruit/detail/index.tsx
@@ -14,13 +14,7 @@ import RecruitNotification from '@/components/recruit/detail/RecruitNotification
 import RecruitParticipationControl from '@/components/recruit/detail/RecruitParticipationControl';
 import RecruitStatusSelectModal from '@/components/recruit/detail/RecruitStatusSelectModal';
 import { selectRecruitStatusAtom } from '@/recoil/modal';
-import { GroupLeaderType, GroupList } from '@/types/recruit';
-
-interface ReadingGroupType {
-  group: GroupList;
-  is_group_lead: boolean;
-  is_participant: boolean;
-}
+import { GroupLeaderType } from '@/types/recruit';
 
 const RecruitDetailPage = () => {
   const {
@@ -32,7 +26,7 @@ const RecruitDetailPage = () => {
     data: groupData,
     isError: isGroupError,
     isLoading: isGroupLoading,
-  } = useQuery<ReadingGroupType>(
+  } = useQuery(
     ['recruitDetail', groupId],
     () => fetchReadingGroupInfo(groupId as string),
     {
@@ -68,7 +62,7 @@ const RecruitDetailPage = () => {
     description,
     meeting_type,
     group_id,
-  } = groupData.group;
+  } = groupData;
 
   const NotificationState = [
     { title: '요일/시간', detail: `매주 ${day} ${time}` },
@@ -128,7 +122,7 @@ const RecruitDetailPage = () => {
           <p>{description}</p>
           <div className='w-full h-[1px] bg-[#EBEAEA] my-8' />
           <h3 className='text-[#67A68A] text-sm'>자세한 정보 알려드려요</h3>
-          <h2 className='text-xl pt-1 font-bold pb-6'>안내사항</h2>
+          <h2 className='pt-1 pb-6 text-xl font-bold'>안내사항</h2>
           {NotificationState.map(({ title, detail }) => (
             <RecruitNotification
               key={title}
@@ -142,8 +136,8 @@ const RecruitDetailPage = () => {
           <h3 className='text-[#67A68A] text-sm'>
             함께 독서하며 소통하고 있어요
           </h3>
-          <div className='flex justify-between items-center pb-5'>
-            <h2 className='text-xl pt-1 font-bold'>멤버 소개</h2>
+          <div className='flex items-center justify-between pb-5'>
+            <h2 className='pt-1 text-xl font-bold'>멤버 소개</h2>
             <Link href={`/recruit/detail/member`}>전체보기</Link>
           </div>
           <div className='flex'>

--- a/src/pages/recruit/detail/index.tsx
+++ b/src/pages/recruit/detail/index.tsx
@@ -66,7 +66,7 @@ const RecruitDetailPage = () => {
 
   const NotificationState = [
     { title: '요일/시간', detail: `매주 ${day} ${time}` },
-    { title: '활동 장소', detail: `매주 ${region}` },
+    { title: '활동 장소', detail: `${region}` },
     {
       title: '참여 인원',
       detail: `${userGroup.length}/${participant_limit}`,

--- a/src/pages/recruit/update.tsx
+++ b/src/pages/recruit/update.tsx
@@ -4,7 +4,6 @@ import { useRouter } from 'next/router';
 import { fetchReadingGroupInfo, patchReadingClassChange } from '@/api/recruit';
 import RecruitForm from '@/components/recruit/RecruitForm';
 import { useGroupForm } from '@/hooks/useGroupForm';
-import { GroupList } from '@/types/recruit';
 
 const RecruitUpdatePage = () => {
   const {
@@ -46,29 +45,16 @@ const RecruitUpdatePage = () => {
     },
   );
 
-  const {
-    name,
-    meeting_type,
-    day,
-    time,
-    region,
-    description,
-    participant_limit,
-    open_chat_link,
-  } = groupData as GroupList;
-
-  const classDataObj = {
-    className: name,
-    classType: meeting_type,
-    classRegion: region,
-    classDescription: description,
-    classDay: day,
-    classTime: time,
-    classPeopleNumber: String(participant_limit),
-    classKakaoLink: open_chat_link,
-  };
-
-  const { classStateObj, classChangeStateObj } = useGroupForm(classDataObj);
+  const { classStateObj, classChangeStateObj } = useGroupForm({
+    className: groupData?.name ?? '',
+    classType: groupData?.meeting_type ?? '',
+    classRegion: groupData?.region ?? '',
+    classDescription: groupData?.description ?? '',
+    classDay: groupData?.day ?? '',
+    classTime: groupData?.time ?? '',
+    classPeopleNumber: String(groupData?.participant_limit ?? ''),
+    classKakaoLink: groupData?.open_chat_link ?? '',
+  });
 
   if (isGroupLoading) return <></>;
   if (isGroupError) return <></>;

--- a/src/pages/recruit/update.tsx
+++ b/src/pages/recruit/update.tsx
@@ -1,0 +1,35 @@
+import { useQuery } from '@tanstack/react-query';
+import { useRouter } from 'next/router';
+
+import { fetchReadingGroupInfo } from '@/api/recruit';
+
+const RecruitUpdatePage = () => {
+  const {
+    query: { groupId },
+  } = useRouter();
+
+  const {
+    data: groupData,
+    isError: isGroupError,
+    isLoading: isGroupLoading,
+  } = useQuery(
+    ['recruitDetail', groupId],
+    () => fetchReadingGroupInfo(groupId as string),
+    {
+      staleTime: Infinity,
+    },
+  );
+
+  console.log(groupData);
+
+  if (isGroupLoading) return <></>;
+  if (isGroupError) return <></>;
+
+  return (
+    <>
+      <h1>독서 모임 수정페이지 입니다.</h1>
+    </>
+  );
+};
+
+export default RecruitUpdatePage;

--- a/src/pages/recruit/update.tsx
+++ b/src/pages/recruit/update.tsx
@@ -1,7 +1,12 @@
 import { useQuery } from '@tanstack/react-query';
 import { useRouter } from 'next/router';
+import tw from 'tailwind-styled-components';
 
 import { fetchReadingGroupInfo } from '@/api/recruit';
+import Header from '@/components/common/Header';
+import RecruitOpenForm from '@/components/recruit/RecruitOpenForm';
+import { useGroupForm } from '@/hooks/useGroupForm';
+import { GroupList } from '@/types/recruit';
 
 const RecruitUpdatePage = () => {
   const {
@@ -20,16 +25,98 @@ const RecruitUpdatePage = () => {
     },
   );
 
-  console.log(groupData);
+  const {
+    name,
+    meeting_type,
+    day,
+    time,
+    region,
+    description,
+    participant_limit,
+    open_chat_link,
+  } = groupData as GroupList;
+
+  const classDataObj = {
+    className: name,
+    classType: meeting_type,
+    classRegion: region,
+    classDescription: description,
+    classDay: day,
+    classTime: time,
+    classPeopleNumber: String(participant_limit),
+    classKakaoLink: open_chat_link,
+  };
+
+  const { classStateObj, classChangeStateObj } = useGroupForm(classDataObj);
 
   if (isGroupLoading) return <></>;
   if (isGroupError) return <></>;
 
   return (
     <>
-      <h1>독서 모임 수정페이지 입니다.</h1>
+      <Container>
+        <Header />
+        <Wrapper>
+          <PageDescription>
+            모임 만들기
+            <br />
+            독서 모임을 개설해 볼까요?
+          </PageDescription>
+          <RecruitOpenFormWrapper>
+            <RecruitOpenForm
+              classStateObj={classStateObj}
+              classChangeStateObj={classChangeStateObj}
+            />
+          </RecruitOpenFormWrapper>
+        </Wrapper>
+        <ClassOpenButtonWrap>
+          {/* <ClassOpenButton onClick={onClickOpenButton}>만들기</ClassOpenButton> */}
+        </ClassOpenButtonWrap>
+      </Container>
     </>
   );
 };
 
 export default RecruitUpdatePage;
+
+const Container = tw.div`
+  h-full
+  bg-white
+`;
+
+const Wrapper = tw.div`
+  px-[5%]
+  mx-auto
+  bg-white
+`;
+
+const PageDescription = tw.h1`
+  text-xl
+  font-bold
+  mt-[10px]
+  mb-[20px]
+`;
+
+const RecruitOpenFormWrapper = tw.div`
+  flex
+  flex-col
+`;
+
+const ClassOpenButtonWrap = tw.div`  
+  border 
+  border-t-[black]
+  border-opacity-10
+  w-full
+  px-[15px]
+  py-[12.5px]
+  bg-white
+`;
+
+const ClassOpenButton = tw.button`  
+  bg-[#67A68A]
+  w-full
+  h-[55px]
+  text-white
+  rounded
+  font-bold
+`;

--- a/src/pages/recruit/update.tsx
+++ b/src/pages/recruit/update.tsx
@@ -1,10 +1,8 @@
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useRouter } from 'next/router';
-import tw from 'tailwind-styled-components';
 
 import { fetchReadingGroupInfo, patchReadingClassChange } from '@/api/recruit';
-import Header from '@/components/common/Header';
-import RecruitFormUserInput from '@/components/recruit/RecruitFormUserInput';
+import RecruitForm from '@/components/recruit/RecruitForm';
 import { useGroupForm } from '@/hooks/useGroupForm';
 import { GroupList } from '@/types/recruit';
 
@@ -76,72 +74,13 @@ const RecruitUpdatePage = () => {
   if (isGroupError) return <></>;
 
   return (
-    <>
-      <Container>
-        <Header />
-        <Wrapper>
-          <PageDescription>
-            모임 만들기
-            <br />
-            독서 모임을 개설해 볼까요?
-          </PageDescription>
-          <RecruitOpenFormWrapper>
-            <RecruitFormUserInput
-              classStateObj={classStateObj}
-              classChangeStateObj={classChangeStateObj}
-            />
-          </RecruitOpenFormWrapper>
-        </Wrapper>
-        <ClassOpenButtonWrap>
-          <ClassOpenButton onClick={onClickUpdateButton}>
-            수정하기
-          </ClassOpenButton>
-        </ClassOpenButtonWrap>
-      </Container>
-    </>
+    <RecruitForm
+      classStateObj={classStateObj}
+      classChangeStateObj={classChangeStateObj}
+      onClickButton={onClickUpdateButton}
+      type='수정'
+    />
   );
 };
 
 export default RecruitUpdatePage;
-
-const Container = tw.div`
-  h-full
-  bg-white
-`;
-
-const Wrapper = tw.div`
-  px-[5%]
-  mx-auto
-  bg-white
-`;
-
-const PageDescription = tw.h1`
-  text-xl
-  font-bold
-  mt-[10px]
-  mb-[20px]
-`;
-
-const RecruitOpenFormWrapper = tw.div`
-  flex
-  flex-col
-`;
-
-const ClassOpenButtonWrap = tw.div`  
-  border 
-  border-t-[black]
-  border-opacity-10
-  w-full
-  px-[15px]
-  py-[12.5px]
-  bg-white
-`;
-
-const ClassOpenButton = tw.button`  
-  bg-[#67A68A]
-  w-full
-  h-[55px]
-  text-white
-  rounded
-  font-bold
-`;

--- a/src/pages/recruit/update.tsx
+++ b/src/pages/recruit/update.tsx
@@ -1,8 +1,8 @@
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { useRouter } from 'next/router';
 import tw from 'tailwind-styled-components';
 
-import { fetchReadingGroupInfo } from '@/api/recruit';
+import { fetchReadingGroupInfo, patchReadingClassChange } from '@/api/recruit';
 import Header from '@/components/common/Header';
 import RecruitOpenForm from '@/components/recruit/RecruitOpenForm';
 import { useGroupForm } from '@/hooks/useGroupForm';
@@ -11,7 +11,30 @@ import { GroupList } from '@/types/recruit';
 const RecruitUpdatePage = () => {
   const {
     query: { groupId },
+    push,
   } = useRouter();
+
+  const { mutate: updateReadingGroup } = useMutation(patchReadingClassChange);
+  const onClickUpdateButton = () => {
+    if (!groupId || Array.isArray(groupId)) return;
+
+    updateReadingGroup({
+      groupId: parseInt(groupId),
+      groupData: {
+        name: classStateObj.className,
+        recruitment_status: true,
+        meeting_type: classStateObj.classType,
+        day: classStateObj.classDay,
+        time: classStateObj.classTime,
+        region: classStateObj.classRegion,
+        description: classStateObj.classDescription,
+        participant_limit: parseInt(classStateObj.classPeopleNumber),
+        open_chat_link: classStateObj.classKakaoLink,
+      },
+    });
+
+    push(`/recruit/detail?groupId=${groupId}`);
+  };
 
   const {
     data: groupData,
@@ -70,7 +93,9 @@ const RecruitUpdatePage = () => {
           </RecruitOpenFormWrapper>
         </Wrapper>
         <ClassOpenButtonWrap>
-          {/* <ClassOpenButton onClick={onClickOpenButton}>만들기</ClassOpenButton> */}
+          <ClassOpenButton onClick={onClickUpdateButton}>
+            수정하기
+          </ClassOpenButton>
         </ClassOpenButtonWrap>
       </Container>
     </>

--- a/src/pages/recruit/update.tsx
+++ b/src/pages/recruit/update.tsx
@@ -4,7 +4,7 @@ import tw from 'tailwind-styled-components';
 
 import { fetchReadingGroupInfo, patchReadingClassChange } from '@/api/recruit';
 import Header from '@/components/common/Header';
-import RecruitOpenForm from '@/components/recruit/RecruitOpenForm';
+import RecruitFormUserInput from '@/components/recruit/RecruitFormUserInput';
 import { useGroupForm } from '@/hooks/useGroupForm';
 import { GroupList } from '@/types/recruit';
 
@@ -86,7 +86,7 @@ const RecruitUpdatePage = () => {
             독서 모임을 개설해 볼까요?
           </PageDescription>
           <RecruitOpenFormWrapper>
-            <RecruitOpenForm
+            <RecruitFormUserInput
               classStateObj={classStateObj}
               classChangeStateObj={classChangeStateObj}
             />

--- a/src/pages/recruit/write.tsx
+++ b/src/pages/recruit/write.tsx
@@ -1,73 +1,29 @@
 import { useMutation } from '@tanstack/react-query';
-import React, { useState } from 'react';
 import tw from 'tailwind-styled-components';
 
 import { postReadingClassOpen } from '@/api/recruit';
 import AuthRequiredPage from '@/components/auth/AuthRequiredPage';
 import Header from '@/components/common/Header';
 import RecruitOpenForm from '@/components/recruit/RecruitOpenForm';
-import {
-  ClassOpenChangeStateObjProps,
-  ClassOpenStateObjProps,
-} from '@/types/recruit';
+import { useGroupForm } from '@/hooks/useGroupForm';
 
 const RecruitWritePage = () => {
   const openReadingClass = useMutation(postReadingClassOpen);
-
-  const [className, setClassName] = useState('');
-  const [classType, setClassType] = useState('online');
-  const [classRegion, setClassRegion] = useState('');
-  const [classDescription, setClassDescription] = useState('');
-  const [classDay, setClassDay] = useState('');
-  const [classTime, setClassTime] = useState('');
-  const [classPeopleNumber, setClassPeopleNumber] = useState('');
-  const [classKakaoLink, setClassKakaoLink] = useState('');
-
-  const classStateObj: ClassOpenStateObjProps = {
-    className,
-    classType,
-    classRegion,
-    classDescription,
-    classDay,
-    classTime,
-    classPeopleNumber,
-    classKakaoLink,
-  };
-
-  const classChangeStateObj: ClassOpenChangeStateObjProps = {
-    changeClassName: (e) => {
-      setClassName(e.target.value);
-    },
-    changeClassType: (type) => {
-      if (type === 'online') setClassType('online');
-      else setClassType('offline');
-    },
-    changeClassRegion: (e) => {
-      const selectedItem = e.target as HTMLUListElement;
-      selectedItem.textContent && setClassRegion(selectedItem.textContent);
-    },
-    changeClassDescription: (e) => {
-      setClassDescription(e.target.value);
-    },
-    changeClassDay: (e) => {
-      const selectedItem = e.target as HTMLUListElement;
-      selectedItem.textContent && setClassDay(selectedItem.textContent);
-    },
-    changeClassTime: (e) => {
-      const selectedItem = e.target as HTMLUListElement;
-      selectedItem.textContent && setClassTime(selectedItem.textContent);
-    },
-    changeClassPeopleNumber: (e) => {
-      setClassPeopleNumber(e.target.value);
-    },
-    changeClassKakaoLink: (e) => {
-      setClassKakaoLink(e.target.value);
-    },
-  };
-
   const onClickOpenButton = () => {
     openReadingClass.mutate(classStateObj);
   };
+
+  const classDataObj = {
+    className: '',
+    classType: 'online',
+    classRegion: '',
+    classDescription: '',
+    classDay: '',
+    classTime: '',
+    classPeopleNumber: '',
+    classKakaoLink: '',
+  };
+  const { classStateObj, classChangeStateObj } = useGroupForm(classDataObj);
 
   return (
     <AuthRequiredPage>

--- a/src/pages/recruit/write.tsx
+++ b/src/pages/recruit/write.tsx
@@ -4,7 +4,7 @@ import tw from 'tailwind-styled-components';
 import { postReadingClassOpen } from '@/api/recruit';
 import AuthRequiredPage from '@/components/auth/AuthRequiredPage';
 import Header from '@/components/common/Header';
-import RecruitOpenForm from '@/components/recruit/RecruitOpenForm';
+import RecruitFormUserInput from '@/components/recruit/RecruitFormUserInput';
 import { useGroupForm } from '@/hooks/useGroupForm';
 
 const RecruitWritePage = () => {
@@ -36,7 +36,7 @@ const RecruitWritePage = () => {
             독서 모임을 개설해 볼까요?
           </PageDescription>
           <RecruitOpenFormWrapper>
-            <RecruitOpenForm
+            <RecruitFormUserInput
               classStateObj={classStateObj}
               classChangeStateObj={classChangeStateObj}
             />

--- a/src/pages/recruit/write.tsx
+++ b/src/pages/recruit/write.tsx
@@ -1,10 +1,7 @@
 import { useMutation } from '@tanstack/react-query';
-import tw from 'tailwind-styled-components';
 
 import { postReadingClassOpen } from '@/api/recruit';
-import AuthRequiredPage from '@/components/auth/AuthRequiredPage';
-import Header from '@/components/common/Header';
-import RecruitFormUserInput from '@/components/recruit/RecruitFormUserInput';
+import RecruitForm from '@/components/recruit/RecruitForm';
 import { useGroupForm } from '@/hooks/useGroupForm';
 
 const RecruitWritePage = () => {
@@ -26,70 +23,13 @@ const RecruitWritePage = () => {
   const { classStateObj, classChangeStateObj } = useGroupForm(classDataObj);
 
   return (
-    <AuthRequiredPage>
-      <Container>
-        <Header />
-        <Wrapper>
-          <PageDescription>
-            모임 만들기
-            <br />
-            독서 모임을 개설해 볼까요?
-          </PageDescription>
-          <RecruitOpenFormWrapper>
-            <RecruitFormUserInput
-              classStateObj={classStateObj}
-              classChangeStateObj={classChangeStateObj}
-            />
-          </RecruitOpenFormWrapper>
-        </Wrapper>
-        <ClassOpenButtonWrap>
-          <ClassOpenButton onClick={onClickOpenButton}>만들기</ClassOpenButton>
-        </ClassOpenButtonWrap>
-      </Container>
-    </AuthRequiredPage>
+    <RecruitForm
+      classStateObj={classStateObj}
+      classChangeStateObj={classChangeStateObj}
+      onClickButton={onClickOpenButton}
+      type='개설'
+    />
   );
 };
 
 export default RecruitWritePage;
-
-const Container = tw.div`
-  h-full
-  bg-white
-`;
-
-const Wrapper = tw.div`
-  px-[5%]
-  mx-auto
-  bg-white
-`;
-
-const PageDescription = tw.h1`
-  text-xl
-  font-bold
-  mt-[10px]
-  mb-[20px]
-`;
-
-const RecruitOpenFormWrapper = tw.div`
-  flex
-  flex-col
-`;
-
-const ClassOpenButtonWrap = tw.div`  
-  border 
-  border-t-[black]
-  border-opacity-10
-  w-full
-  px-[15px]
-  py-[12.5px]
-  bg-white
-`;
-
-const ClassOpenButton = tw.button`  
-  bg-[#67A68A]
-  w-full
-  h-[55px]
-  text-white
-  rounded
-  font-bold
-`;

--- a/src/types/recruit.d.ts
+++ b/src/types/recruit.d.ts
@@ -1,4 +1,4 @@
-export interface ClassOpenStateObjProps {
+export interface GroupFormStateObjProps {
   className: string;
   classType: string;
   classRegion: string;
@@ -9,7 +9,7 @@ export interface ClassOpenStateObjProps {
   classKakaoLink: string;
 }
 
-export interface ClassOpenChangeStateObjProps {
+export interface GroupFormChangeStateObjProps {
   changeClassName: (e: React.ChangeEvent<HTMLInputElement>) => void;
   changeClassType: (type: string) => void;
   changeClassRegion: (e: React.MouseEvent<HTMLUListElement>) => void;


### PR DESCRIPTION
## 📌 이슈 번호

- close #169 

## 👩‍💻 작업 내용

- commit 내역을 통해 작업 내역 확인하시면 될 것 같습니다~
- 페이지 디자인은 독서 모임 개설 페이지와 동일합니다~

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

- 현재 GroupFormStateObjProps, GroupList 이 두 interface를 하나의 interface로 수정하는 작업을 해야할 것 같습니다~
- @YJZero 소스코드 중복 방지를 위해  patchReadingClassChange에서 서버에 넘겨줄 데이터 처리하는 하는 것은 어떨까요?
ex) => 같은 파일의 postReadingClassOpen 함수
