### PR TITLE
fix: 추천 페이지 이미 담은 책일 때 에러 처리

### DIFF
--- a/src/pages/recommend/result.tsx
+++ b/src/pages/recommend/result.tsx
@@ -1,4 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
 import React, { useEffect, useState } from 'react';
@@ -44,6 +45,12 @@ const RecommendResultPage = () => {
     postMyBookshelf(addBookshelf, {
       onSuccess: () => {
         alert('내 책장에 책을 담았습니다.');
+      },
+      onError: (error) => {
+        const { status } = error as AxiosError;
+        if (status === 403) {
+          alert('이미 책장에 저장된 책입니다.');
+        }
       },
     });
   };


### PR DESCRIPTION
## 📌 이슈 번호

- close #232  <!-- 링크 달기 -->

## 👩‍💻 작업 내용

<!-- 자세히 쓰기 - 이미지가 필요한 경우 첨부하기, 영상도 ok -->
- 책장에 이미 담은 책일 때 에러 처리 부분입니다.
- 재홍님께서 이미 작성해주신 부분이 있어서 동일하게 적용해두었어요!
- 지금은 alert인데 나중에 토스트 ui 등으로 적용해도 좋을 것 같아요!

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

<!-- 참고할 사항이 있다면 적어주세요 -->
