### PR TITLE
fix: 리스트 데이터 render 하지 못하는 문제

### DIFF
--- a/src/components/recruit/RecruitInfinityScrollLists.tsx
+++ b/src/components/recruit/RecruitInfinityScrollLists.tsx
@@ -61,9 +61,8 @@ const RecruitInfinityScrollLists = ({
       {status === 'success' && (
         <>
           {readingGroupLists.pages.map(
-            ({ groups, currentPage }, index) =>
-              groups.length > 0 &&
-              groups[index] && (
+            ({ groups, currentPage }) =>
+              groups.length > 0 && (
                 <RecruitList key={currentPage} listData={groups} />
               ),
           )}


### PR DESCRIPTION
## 📌 이슈 번호

- close #286 

## 👩‍💻 작업 내용

- 이슈에 발생했던 버그 관련해 작성해두었습니다.
- 해결 방법
  - groups[index] 제거
  - groups[index] => n번째 그룹데이터의 n번 index의 데이터가 존재하면 true
  - 예를들어 현재 총 30개의 리스트 아이템이 있고 스크롤 할 때 마다 5개의 아이템을 render 한다고 가정하겠습니다.(총 그룹 수: 6개)
  - 첫번째 그룹 => 첫번째 그룹의 groups[1(그룹번호)](데이터가 있어서 render)
  - 두번째 그룹 => 두번째 그룹의 groups[2](데이터가 있어서 render)
  - 다섯번째 그룹 => 다섯번째 그룹의 groups[5](1개의 그룹에는 5개의 아이템만 있기 때문에 특정 그룹 index의 최대값은 4이다. 하지만 5번째 index를 조회함으로 인해 false가 반환되고 그로인해 다섯 번째 그룹에 해당하는 리스트가 render가 안됨. 그 뒤의 그룹도 마찬가지 이유로 render가 안됬다.)
- 처음에는 index가 각 그룹 아이템에 따라 달라진다고 생각을 해서 해당 코드를 작성했습니다. 하지만 그룹에 따라 index가 달라지기 때문에 이런 문제가 발생하였습니다.

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

<!-- 참고할 사항이 있다면 적어주세요 -->
