### PR TITLE
fix: 스크롤이 최 하단 상태일 때 보이는 리스트 아이템 수정 시 반영 안됨

### DIFF
--- a/src/components/recruit/RecruitInfinityScrollLists.tsx
+++ b/src/components/recruit/RecruitInfinityScrollLists.tsx
@@ -47,8 +47,10 @@ const RecruitInfinityScrollLists = ({
   );
 
   useEffect(() => {
-    if (inView) fetchNextPage();
-  }, [fetchNextPage, inView]);
+    if (!inView) return;
+
+    hasNextPage && fetchNextPage();
+  }, [fetchNextPage, inView, hasNextPage]);
 
   useEffect(() => {
     if (infinityScrollPosition !== 0) {
@@ -61,9 +63,8 @@ const RecruitInfinityScrollLists = ({
       {status === 'success' && (
         <>
           {readingGroupLists.pages.map(
-            ({ groups, currentPage }, index) =>
-              groups.length > 0 &&
-              groups[index] && (
+            ({ groups, currentPage }) =>
+              groups.length > 0 && (
                 <RecruitList key={currentPage} listData={groups} />
               ),
           )}


### PR DESCRIPTION
모임 개설 시에도 최 하단에 아이템이 추가되기 때문에 반영 안되는 문제 있었음

## 📌 이슈 번호

- close #289 
- 블로그에 작성할 예정이여서 길게 기록했습니다~ 내용 참고하셔서 소스코드 보시면 이해에 도움이 되실 겁니다! 

## 👩‍💻 작업 내용

- 이슈에 문제 상황 요약해두었습니다~
- 문제 상황
![데이터-반영x](https://github.com/dugeun-dugeun-project/frontend/assets/60873508/f4ef6b2b-4f62-4708-b2ce-f08b3a1b46d8)

- 데이터를 정상적으로 fetch 하지 못하기 때문일 것이라는 1차적인 생각이 들었습니다.
  - 네트워크 탭 
  ![network 탭에서 확인](https://github.com/dugeun-dugeun-project/frontend/assets/60873508/9528bf7c-58ca-441b-8214-90d7b05764ee)

  - api 함수 호출하는 곳
  ![api 함수](https://github.com/dugeun-dugeun-project/frontend/assets/60873508/85db8295-b1e0-4d12-a03a-da667c03dda3)

- 위의 사진과 같이 정상적으로 수정된 데이터를 fetch 해오는 것을 볼 수 있습니다. 반면에 컴포넌트에서 콘솔에 데이터를 찍어보면 이전데이터가 보입니다...
   ![컴포넌트에서 render](https://github.com/dugeun-dugeun-project/frontend/assets/60873508/ebc6b989-2852-4393-b97e-08af020ab8d9)

- 데이터 fetch 자체에 문제가 있는 것이 아니라 최하단에서만 해당 문제가 발생하니까 inView에 문제가 있지 않을까라는 생각을했습니다. 그 생각에 착안해 스크롤이 최하단일 때와 그 이외의 상황일 때 useEffect 안에서 콘솔을 찍어보았습니다.
  - 최하단에서는 inView가 true이기 때문에 fetchNextPage 호출
  ![최하단에서는 fetchNextPage 호출](https://github.com/dugeun-dugeun-project/frontend/assets/60873508/2b017720-cd74-44ab-b0fe-ca58743f760c)
  - 최하단이 아닌 경우에는 fetchNextPage 호출 안함
  ![최하단이 아니면 fetchNextPage 호출 안함](https://github.com/dugeun-dugeun-project/frontend/assets/60873508/11fced92-8e7b-47cc-8208-7501cfc996c0)
  - 위의 결과를 바탕으로 최하단일 때도 fetchNextPage가 호출되지 않도록 함으로써(hasNextPage 사용) 문제를 해결할 수 있었습니다.
  ![데이터-반영-o](https://github.com/dugeun-dugeun-project/frontend/assets/60873508/936e96ff-9642-4f76-8352-b80090f81db1)


- fetchNextPage가 호출 되면 수정 된 데이터를 render 하지 못하는 이유
  - 결론부터 말씀드리면 최신 데이터를 반영하지 못하는 이유는 `fetchNextPage 호출`이지만 구체적인 이유와 `enabled에 의한 query 활성화`와의 인과관계를 정확히 파악하지는 못했습니다.
  - 저는 단지 fetchNextPage가 호출됨으로 인해 왜 수정된 데이터를 render 하지 못하는지 이해하기 어려웠습니다. enabled에 의해 query가 다시 활성화 되고 있기도 했구요.
  - fetchNextPage에 대한 개념을 찾아봤지만 다음 페이지가 있을 경우 다음 페이지 데이터를 가져온다는 설명밖에 없었습니다.
  - 모든 상황에서 해당 개념이 동일하게 동작하지 않는다는 생각을 바탕으로 현재 상황을 분석해보았습니다 => `query에 이전 데이터가 캐싱되어 있고 가져올 다음 페이지가 없을 때 컴포넌트가 마운트 된 후 fetchNextPage()가 수행, 그 후에 enabled에 의해 쿼리 활성화`
  - 위의 상황에서 발생되는 현상과 관련해 chat GPT에게 물어봤고 이와 같은 답변을 해주었습니다 
    - 위의 상황에서 fetchNextPage()가 수행가 수행되는 경우 => 이미 존재하는 데이터를 활용하여 컴포넌트가 렌더링됩니다. 하지만 실제로 새로운 데이터가 없으므로 화면에 변경된 내용은 없을 수 있습니다.`
    - `fetchNextPage와 enabled에 의한 쿼리 활성화가 동시에 발생하면 데이터 중복현상이 발생할 수 있음`
  - 즉, fetchNextPage와 쿼리 활성화 동작이 동시에 일어나다보니 최신데이터를 render 하지 못한다고 추측할 수 있을 것 같습니다.

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

<!-- 참고할 사항이 있다면 적어주세요 -->
