### PR TITLE
fix: 독서 모임 개설, 수정 후 refetch 하는 동안 comment render

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -13,7 +13,7 @@ const Header = ({ title, moreMenu, className, pathname }: Props) => {
   const {
     push,
     back,
-    query: { islistchange },
+    query: { listchangetype },
   } = useRouter();
 
   return (
@@ -28,7 +28,7 @@ const Header = ({ title, moreMenu, className, pathname }: Props) => {
             pathname
               ? push({
                   pathname,
-                  query: islistchange && { islistchange },
+                  query: listchangetype && { listchangetype },
                 })
               : back();
           }}

--- a/src/components/recruit/RecruitInfinityScrollLists.tsx
+++ b/src/components/recruit/RecruitInfinityScrollLists.tsx
@@ -32,6 +32,7 @@ const RecruitInfinityScrollLists = ({
     hasNextPage,
     isFetchingNextPage,
     status,
+    isRefetching,
   } = useInfiniteQuery(
     ['reading', 'group', 'list'],
     ({ pageParam = 1 }) => getReadingClassData(pageParam),
@@ -51,10 +52,20 @@ const RecruitInfinityScrollLists = ({
   }, [fetchNextPage, inView]);
 
   useEffect(() => {
-    if (infinityScrollPosition !== 0) {
-      window.scrollTo(0, infinityScrollPosition);
-    }
-  }, []);
+    if (infinityScrollPosition === 0 || (islistchange && isRefetching)) return;
+
+    window.scrollTo(0, infinityScrollPosition);
+  }, [isRefetching]);
+
+  if (isRefetching) {
+    return (
+      <div>
+        {islistchange === 'update'
+          ? '수정하신 내용을 기반으로 업데이트하고 있어요!'
+          : '새로운 모임이 추가되고 있어요!'}
+      </div>
+    );
+  }
 
   return (
     <Container>

--- a/src/components/recruit/RecruitInfinityScrollLists.tsx
+++ b/src/components/recruit/RecruitInfinityScrollLists.tsx
@@ -10,11 +10,11 @@ import { readingGroupInfinityScrollPositionAtom } from '@/recoil/recruit';
 import RecruitList from './RecruitList';
 
 interface RecruitInfinityScrollListsProps {
-  islistchange?: string;
+  listchangetype?: string;
 }
 
 const RecruitInfinityScrollLists = ({
-  islistchange,
+  listchangetype,
 }: RecruitInfinityScrollListsProps) => {
   const { ref, inView } = useInView();
   const infinityScrollPosition = useRecoilValue(
@@ -43,7 +43,7 @@ const RecruitInfinityScrollLists = ({
 
         return parseInt(lastPage.currentPage) + 1;
       },
-      enabled: !readingGroupQueryData.current || !!islistchange,
+      enabled: !readingGroupQueryData.current || !!listchangetype,
     },
   );
 
@@ -52,7 +52,8 @@ const RecruitInfinityScrollLists = ({
   }, [fetchNextPage, inView]);
 
   useEffect(() => {
-    if (infinityScrollPosition === 0 || (islistchange && isRefetching)) return;
+    if (infinityScrollPosition === 0 || (listchangetype && isRefetching))
+      return;
 
     window.scrollTo(0, infinityScrollPosition);
   }, [isRefetching]);
@@ -60,7 +61,7 @@ const RecruitInfinityScrollLists = ({
   if (isRefetching) {
     return (
       <div>
-        {islistchange === 'update'
+        {listchangetype === 'update'
           ? '수정하신 내용을 기반으로 업데이트하고 있어요!'
           : '새로운 모임이 추가되고 있어요!'}
       </div>

--- a/src/pages/recruit/index.tsx
+++ b/src/pages/recruit/index.tsx
@@ -16,7 +16,7 @@ const RecruitPage = () => {
   );
   const {
     push,
-    query: { islistchange },
+    query: { listchangetype },
   } = useRouter();
 
   const clickGroupOpenButton = () => {
@@ -43,7 +43,9 @@ const RecruitPage = () => {
       <InfinityScrollListsWrap>
         <InfinityScrollLists>
           <RecruitInfinityScrollLists
-            islistchange={typeof islistchange === 'string' ? islistchange : ''}
+            listchangetype={
+              typeof listchangetype === 'string' ? listchangetype : ''
+            }
           />
         </InfinityScrollLists>
       </InfinityScrollListsWrap>

--- a/src/pages/recruit/index.tsx
+++ b/src/pages/recruit/index.tsx
@@ -1,15 +1,19 @@
 import { useRouter } from 'next/router';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 import tw from 'tailwind-styled-components';
 
 import BottomNav from '@/components/common/BottomNav';
 import RecruitInfinityScrollLists from '@/components/recruit/RecruitInfinityScrollLists';
 import { useAuth } from '@/hooks/useAuth';
 import { isAuthorizedSelector } from '@/recoil/auth';
+import { readingGroupInfinityScrollPositionAtom } from '@/recoil/recruit';
 
 const RecruitPage = () => {
   const { openAuthRequiredModal } = useAuth();
   const isAuthorized = useRecoilValue(isAuthorizedSelector);
+  const setInfinityScrollPosition = useSetRecoilState(
+    readingGroupInfinityScrollPositionAtom,
+  );
   const {
     push,
     query: { islistchange },
@@ -21,6 +25,7 @@ const RecruitPage = () => {
       return;
     }
 
+    setInfinityScrollPosition(window.scrollY);
     push('/recruit/write');
   };
 

--- a/src/pages/recruit/update.tsx
+++ b/src/pages/recruit/update.tsx
@@ -19,7 +19,7 @@ const RecruitUpdatePage = () => {
         pathname: '/recruit/detail',
         query: {
           groupId,
-          islistchange: 'update',
+          listchangetype: 'update',
         },
       });
     },

--- a/src/pages/recruit/update.tsx
+++ b/src/pages/recruit/update.tsx
@@ -19,7 +19,7 @@ const RecruitUpdatePage = () => {
         pathname: '/recruit/detail',
         query: {
           groupId,
-          islistchange: true,
+          islistchange: 'update',
         },
       });
     },

--- a/src/pages/recruit/write.tsx
+++ b/src/pages/recruit/write.tsx
@@ -16,7 +16,7 @@ const RecruitWritePage = () => {
       push({
         pathname: '/recruit',
         query: {
-          islistchange: 'open',
+          listchangetype: 'open',
         },
       });
     },

--- a/src/pages/recruit/write.tsx
+++ b/src/pages/recruit/write.tsx
@@ -16,7 +16,7 @@ const RecruitWritePage = () => {
       push({
         pathname: '/recruit',
         query: {
-          islistchange: true,
+          islistchange: 'open',
         },
       });
     },


### PR DESCRIPTION
## 📌 이슈 번호

- close #291 

## 👩‍💻 작업 내용

- 이슈에 해당 작업을 해야하는 이유 작성해두었습니다.
- 독서 모임 개설(책 매니아들 이라는 제목의 모임 생성)
![개설](https://github.com/dugeun-dugeun-project/frontend/assets/60873508/2e2f829d-a4d3-456e-ae52-e068a6fde9c3)

- 독서 모임 수정(독서 하는 거인 => 독서 하는 거인 수정)
![수정](https://github.com/dugeun-dugeun-project/frontend/assets/60873508/8ce8670a-3283-4a40-bee7-07d7b373a163)


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

- 일단 제 판단하에 해당 작업을 진행했는데 도입해도 괜찮을 것 같다고 생각하시면 코멘트 및 디자인도 부탁드려야 할 것 같습니다!
- 현재 독서 모임 개설 후 상세 페이지로 이동하지 않는 이유는 이전 작업의 PR이 Merge 되지 않아서 입니다.
