### PR TITLE
refactor: 비로그인 유저가 bottom nav bar 기록, 홈 클릭 시 메인 유지

### DIFF
--- a/src/components/common/BottomNav.tsx
+++ b/src/components/common/BottomNav.tsx
@@ -11,6 +11,7 @@ interface ButtonType {
   src: string;
   text: string;
   path: string;
+  as?: string;
   onClick?: () => void;
 }
 
@@ -22,7 +23,8 @@ const BottomNav = () => {
 
   const navItemPropertyArr: ButtonType[] = [
     {
-      path: '/',
+      path: '/?isRendedOnboarding=true',
+      as: '/',
       text: '홈',
       src: 'home',
     },
@@ -32,7 +34,8 @@ const BottomNav = () => {
       src: 'search',
     },
     {
-      path: isAuthorized ? '/book/record' : '',
+      path: isAuthorized ? '/book/record' : '/?isRendedOnboarding=true',
+      as: '/',
       text: '기록',
       src: 'record',
       onClick: () => {
@@ -55,11 +58,11 @@ const BottomNav = () => {
     <Container>
       <Wrap>
         {navItemPropertyArr.map((button: ButtonType) => {
-          const { path, text, onClick, src } = button;
+          const { path, text, onClick, src, as } = button;
           const isClicked = path === pathname;
 
           return (
-            <Button href={path} key={src}>
+            <Button href={path} as={as && as} key={src}>
               <Image
                 width={45}
                 height={45}

--- a/src/components/common/BottomNav.tsx
+++ b/src/components/common/BottomNav.tsx
@@ -12,6 +12,7 @@ interface ButtonType {
   text: string;
   path: string;
   as?: string;
+  scroll?: boolean;
   onClick?: () => void;
 }
 
@@ -37,6 +38,7 @@ const BottomNav = () => {
       path: isAuthorized ? '/book/record' : '/?isRendedOnboarding=true',
       as: '/',
       text: '기록',
+      scroll: isAuthorized,
       src: 'record',
       onClick: () => {
         isAuthorized || openAuthRequiredModal();
@@ -58,11 +60,11 @@ const BottomNav = () => {
     <Container>
       <Wrap>
         {navItemPropertyArr.map((button: ButtonType) => {
-          const { path, text, onClick, src, as } = button;
+          const { path, text, onClick, src, as, scroll = true } = button;
           const isClicked = path === pathname;
 
           return (
-            <Button href={path} as={as && as} key={src}>
+            <Button href={path} as={as && as} scroll={scroll} key={src}>
               <Image
                 width={45}
                 height={45}


### PR DESCRIPTION
## 📌 이슈 번호

- close #281  <!-- 링크 달기 -->

## 👩‍💻 작업 내용

<!-- 자세히 쓰기 - 이미지가 필요한 경우 첨부하기, 영상도 ok -->
비로그인 유저가 bottom nav bar에서 기록, 홈 클릭 시 온보딩으로 이동하던 부분 메인 유지되도록 수정하였습니다.

 **로그아웃 시**
 :로그아웃 시에도 메인으로 가도록 쿼리값 설정해주었는데 페이지에 query 값이 제대로 안 들어오더라구요! 정확한 원인 파악이 안되었는데 테스트해봤을 때 `setIsAutorized` 의 유무에 따라 없으면 쿼리 값이 제대로 들어오고,   `setIsAutorized`가 있으면 query 안 들어오는 것을 확인했습니다. 해당 로직가 무언가 관련이 있는 것 같아요!

 -> 전체 회의 할 때 로그아웃 시 온보딩보다 메인으로 보내는 게 나을지 회의해보고 메인으로 결정된다면 쿼리가 아니라 로컬스토리지 등의 다른 방법을 사용해야 할 것 같네요! 일단 후작업으로 두겠습니다!

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

<!-- 참고할 사항이 있다면 적어주세요 -->
