### PR TITLE
fix: 도서 검색 페이지

### DIFF
--- a/src/components/book/search/InfinityScrollLists.tsx
+++ b/src/components/book/search/InfinityScrollLists.tsx
@@ -66,11 +66,8 @@ const InfinityScrollLists = ({ searchKeyword }: InfinityScrollListsProps) => {
       {status === 'success' && (
         <>
           {bookSearchResultLists.pages.map(({ documents }, index) =>
-            documents.length > 0 && documents[index] ? (
-              <SearchResultList
-                key={documents[index].isbn}
-                listData={documents}
-              />
+            documents.length > 0 ? (
+              <SearchResultList key={index} listData={documents} />
             ) : (
               <div key='not-search-result'>검색 결과가 없습니다.</div>
             ),

--- a/src/components/book/search/InfinityScrollLists.tsx
+++ b/src/components/book/search/InfinityScrollLists.tsx
@@ -56,7 +56,9 @@ const InfinityScrollLists = ({ searchKeyword }: InfinityScrollListsProps) => {
   }, [fetchNextPage, inView]);
 
   useEffect(() => {
-    if (searchKeyword && !isBookSearchData) setPage(1);
+    if (isBookSearchData) return;
+
+    searchKeyword && setPage(1);
   }, [searchKeyword, setPage, isBookSearchData]);
 
   return (

--- a/src/components/book/search/InfinityScrollLists.tsx
+++ b/src/components/book/search/InfinityScrollLists.tsx
@@ -1,5 +1,5 @@
 import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query';
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { useInView } from 'react-intersection-observer';
 import { useRecoilState } from 'recoil';
 import tw from 'tailwind-styled-components';
@@ -17,15 +17,13 @@ const InfinityScrollLists = ({ searchKeyword }: InfinityScrollListsProps) => {
   const { ref, inView } = useInView();
   const [page, setPage] = useRecoilState(searchInfinityScrollPageAtom);
   const queryClient = useQueryClient();
-  const bookSearchData = useRef(
-    queryClient.getQueryData([
-      'book',
-      'search',
-      'result',
-      'list',
-      searchKeyword,
-    ]),
-  );
+  const isBookSearchData = !!queryClient.getQueryData([
+    'book',
+    'search',
+    'result',
+    'list',
+    searchKeyword,
+  ]);
 
   const {
     data: bookSearchResultLists,
@@ -44,7 +42,7 @@ const InfinityScrollLists = ({ searchKeyword }: InfinityScrollListsProps) => {
 
         return page;
       },
-      enabled: !!searchKeyword && !bookSearchData.current,
+      enabled: !!searchKeyword && !isBookSearchData,
     },
   );
 
@@ -58,8 +56,8 @@ const InfinityScrollLists = ({ searchKeyword }: InfinityScrollListsProps) => {
   }, [fetchNextPage, inView]);
 
   useEffect(() => {
-    if (searchKeyword && !bookSearchData.current) setPage(1);
-  }, [searchKeyword, setPage]);
+    if (searchKeyword && !isBookSearchData) setPage(1);
+  }, [searchKeyword, setPage, isBookSearchData]);
 
   return (
     <Container>

--- a/src/components/common/SearchInput.tsx
+++ b/src/components/common/SearchInput.tsx
@@ -4,10 +4,11 @@ import tw from 'tailwind-styled-components';
 
 interface Props {
   onSubmit(keywrod: string): void;
+  inputText?: string;
 }
 
-const SearchInput = ({ onSubmit }: Props) => {
-  const [inputData, setInputData] = useState('');
+const SearchInput = ({ onSubmit, inputText }: Props) => {
+  const [inputData, setInputData] = useState(inputText);
   const [isError, setIsError] = useState(false);
 
   const updateInputData = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -19,16 +20,10 @@ const SearchInput = ({ onSubmit }: Props) => {
   };
 
   const onClickSearchButton = () => {
+    if (!inputData) return setIsError(true);
+
     onSubmit(inputData);
-
-    if (!inputData) {
-      setIsError(true);
-      return;
-    }
-
-    if (isError) {
-      setIsError(false);
-    }
+    if (isError) setIsError(false);
   };
 
   return (

--- a/src/pages/book/search/index.tsx
+++ b/src/pages/book/search/index.tsx
@@ -37,7 +37,7 @@ const BookSearchPage = () => {
               찾고 계신가요?
             </Title>
             <SearchInputWrap>
-              <SearchInput onSubmit={onSubmit} />
+              <SearchInput onSubmit={onSubmit} inputText={searchBookTitle} />
             </SearchInputWrap>
           </BackGround>
         </BackGroundWrap>


### PR DESCRIPTION
## 📌 이슈 번호

- close #303 

## 👩‍💻 작업 내용

- 도서 검색페이지에 발생하는 오류 이슈에 작성해두었습니다.

- 다른 페이지 갔다 왔을 때 input에 입력한 제목 그대로 유지되지 않는 이유 및 해결 방법
  -  이유 => SearchInput 컴포넌트의 사용자가 입력하는 텍스트의 데이터를 `const [inputData, setInputData] = useState('');`로 관리하기 때문에 다른 페이지 갔다가 다시 페이지가 re-render 되면 제목 유지가 안 됨
  - 해결 방법 => re-render 될 때 상위 컴포넌트로부터 전달 받은 props 값이 render 되도록 함으로써 해결

-  검색 후 다른 페이지 갔다가오면 검색 안됨
    - 검색이 안되는 이유는 enables 값이 false이기 때문이라고 생각을 했다.
    - `(enabled: !!searchKeyword && !bookSearchData.current)`
    - 새롭게 검색 하는 상황에 콘솔에 찍어보니 bookSearchData.current 값이 존재했다.
    - 그래서 새롭게 검색 할 때 이전 쿼리값을 삭제하는 방법을 시도해보았다.(queryClient.removeQueries)
    - 그러나 여전히 검색이 되지 않았고 오히려 이전에 검색한 데이터가 캐싱되지 않으니 UX 저하라는 문제가 발생했다.
    - 그러다 문득 useRef의 current 값은 컴포넌트가 mount 될 때 설정된 값을 re-render가 되어도 계속 유지 한다는 말이 생각났다. 그로인해 검색어가 바껴도 bookSearchData가 이전 데이터를 가지고 있으므로 쿼리가 비 활성화 되어 검색이 안되었던 것이었다.
    - useRef를 제거하니 정상적으로 동작했다!
    - `useRef`
      - ref 객체를 생성하고 current 속성을 통해 값을 수정 및 조회할 수 있음
      - 컴포넌트 re-render 되어도 컴포넌트가 마운트 될 때의 초기값을 유지(ref 객체는 컴포넌트의 라이프사이클 동안 일관된 값을 유지)
      - current 값이 수정되어도 컴포넌트가 re-render 되지 않는다.

- 어느 시점 부터 데이터를 fetch 및 render 하지 못하는 문제
  - https://github.com/dugeun-dugeun-project/frontend/pull/288

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

<!-- 참고할 사항이 있다면 적어주세요 -->
