### PR TITLE
fix: bottom nav 기록 as 제거 및 경고 제거

### DIFF
--- a/src/components/common/BottomNav.tsx
+++ b/src/components/common/BottomNav.tsx
@@ -33,7 +33,6 @@ const BottomNav = () => {
     },
     {
       path: '/book/record',
-      as: '/',
       text: '기록',
       src: 'record',
     },

--- a/src/components/common/BottomNav.tsx
+++ b/src/components/common/BottomNav.tsx
@@ -71,7 +71,7 @@ const BottomNav = () => {
                   isClicked ? 'on' : 'off'
                 }.svg`}
               />
-              <Text isClick={isClicked ? 'click' : ''}>{text}</Text>
+              <Text $isClick={isClicked ? 'click' : ''}>{text}</Text>
             </Button>
           );
         })}
@@ -112,8 +112,9 @@ const Button = tw.button`
   cursor-pointer
 `;
 
-const Text = tw.div<{ isClick: string }>`
+const Text = tw.div<{ $isClick: string }>`
   text-xs	
   mt-[-5px]
-  ${(props) => (props.isClick === 'click' ? 'text-[#60B28D]' : 'text-[#707070')}
+  ${(props) =>
+    props.$isClick === 'click' ? 'text-[#60B28D]' : 'text-[#707070'}
 `;


### PR DESCRIPTION
## 📌 이슈 번호

- close #329  <!-- 링크 달기 -->

## 👩‍💻 작업 내용

<!-- 자세히 쓰기 - 이미지가 필요한 경우 첨부하기, 영상도 ok -->
- bottom nav 기록 부분에서 as를 제거하지 않아 주소가 잘못 전달되고 있어서 새로고침 시 메인으로 가는 버그가 있었습니다! as 제거로 해결하였습니다.
- bottom nav에서 `isClick` 관련 경고가 계속 출력 되어 이 부분 제거하였습니다! @Park-min-hyoung 확인 부탁드립니다!
  - `isClick` 이 스타일에 전달되는 요소인데 Dom에도 그려지는 게 문제라고 합니다. 따라서 `$` 표시를 붙임으로써 DOM요소로 렌더링 되지 않도록 할 수 있다고 하네요! 


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
`$` 표시 관련 문서입니다.
https://styled-components.com/docs/api#transient-props

<!-- 참고할 사항이 있다면 적어주세요 -->
