### PR TITLE
feat: 메인 기록 무한스크롤 페이지 이동 시 스크롤 유지

### DIFF
--- a/src/components/main/mainRecordFeed/FeedItem.tsx
+++ b/src/components/main/mainRecordFeed/FeedItem.tsx
@@ -5,6 +5,7 @@ import React, { useState } from 'react';
 import { useRecoilValue } from 'recoil';
 
 import { useAuth } from '@/hooks/useAuth';
+import useRememberScroll from '@/hooks/useRememberScroll';
 import { isAuthorizedSelector } from '@/recoil/auth';
 import { RecordType } from '@/types/record';
 
@@ -15,6 +16,7 @@ const FeedItem = ({ text, book, user, recordId }: RecordType) => {
   const router = useRouter();
 
   const { openAuthRequiredModal } = useAuth();
+  const { setScroll } = useRememberScroll('mainFeed');
 
   const isAuthorized = useRecoilValue(isAuthorizedSelector);
 
@@ -23,7 +25,7 @@ const FeedItem = ({ text, book, user, recordId }: RecordType) => {
       openAuthRequiredModal();
       return;
     }
-
+    setScroll();
     router.push({
       pathname: 'book/feed',
       query: {

--- a/src/components/main/mainRecordFeed/RecordFeedList.tsx
+++ b/src/components/main/mainRecordFeed/RecordFeedList.tsx
@@ -34,7 +34,7 @@ const RecordFeedList = () => {
   }, [inView, hasNextPage, fetchNextPage]);
 
   useEffect(() => {
-    if (currentScroll !== '0') {
+    if (currentScroll) {
       window.scrollTo(0, Number(currentScroll));
       resetScroll();
     }
@@ -54,7 +54,7 @@ const RecordFeedList = () => {
           <FeedItem {...feed} />
         </Fragment>
       ))}
-      <div ref={ref} className=' h-4'></div>
+      <div ref={ref} className='h-4 '></div>
     </div>
   );
 };

--- a/src/components/main/mainRecordFeed/RecordFeedList.tsx
+++ b/src/components/main/mainRecordFeed/RecordFeedList.tsx
@@ -3,6 +3,7 @@ import React, { Fragment, useEffect } from 'react';
 import { useInView } from 'react-intersection-observer';
 
 import { fetchRecord } from '@/api/record';
+import useRememberScroll from '@/hooks/useRememberScroll';
 
 import FeedItem from './FeedItem';
 
@@ -14,21 +15,30 @@ const RecordFeedList = () => {
     fetchNextPage,
     hasNextPage,
   } = useInfiniteQuery(
-    ['mainFeed'],
+    ['feed', 'mainFeed'],
     ({ pageParam = Number.MAX_SAFE_INTEGER }) => fetchRecord(pageParam, 5),
     {
       getNextPageParam: (lastPage) => {
         if (!lastPage.lastId) return;
         return lastPage.lastId;
       },
+      staleTime: 1000 * 60 * 5,
     },
   );
 
   const [ref, inView] = useInView();
+  const { currentScroll, resetScroll } = useRememberScroll('mainFeed');
 
   useEffect(() => {
     if (inView && hasNextPage) fetchNextPage();
   }, [inView, hasNextPage, fetchNextPage]);
+
+  useEffect(() => {
+    if (currentScroll !== '0') {
+      window.scrollTo(0, Number(currentScroll));
+      resetScroll();
+    }
+  }, [currentScroll, resetScroll]);
 
   if (isError) return <></>;
   if (isLoading) return <></>;

--- a/src/hooks/useRememberScroll.ts
+++ b/src/hooks/useRememberScroll.ts
@@ -1,9 +1,9 @@
 import { useState } from 'react';
 
 const useRememberScroll = (key: string) => {
-  const [currentScroll, setCurrentScroll] = useState(() => {
+  const [currentScroll, setCurrentScroll] = useState<number>(() => {
     const saveScroll = localStorage.getItem(key);
-    return saveScroll ? JSON.parse(saveScroll) : '0';
+    return saveScroll ? JSON.parse(saveScroll) : 0;
   });
 
   const setScroll = () => {
@@ -13,7 +13,7 @@ const useRememberScroll = (key: string) => {
   };
 
   const resetScroll = () => {
-    setCurrentScroll('0');
+    setCurrentScroll(0);
     localStorage.removeItem(key);
   };
   return { currentScroll, setScroll, resetScroll };

--- a/src/hooks/useRememberScroll.ts
+++ b/src/hooks/useRememberScroll.ts
@@ -1,0 +1,22 @@
+import { useState } from 'react';
+
+const useRememberScroll = (key: string) => {
+  const [currentScroll, setCurrentScroll] = useState(() => {
+    const saveScroll = localStorage.getItem(key);
+    return saveScroll ? JSON.parse(saveScroll) : '0';
+  });
+
+  const setScroll = () => {
+    const currentY = window.scrollY;
+    setCurrentScroll(currentY);
+    localStorage.setItem(key, JSON.stringify(currentY));
+  };
+
+  const resetScroll = () => {
+    setCurrentScroll('0');
+    localStorage.removeItem(key);
+  };
+  return { currentScroll, setScroll, resetScroll };
+};
+
+export default useRememberScroll;

--- a/src/pages/book/record/index.tsx
+++ b/src/pages/book/record/index.tsx
@@ -3,6 +3,7 @@ import {
   QueryClient,
   useMutation,
   useQuery,
+  useQueryClient,
 } from '@tanstack/react-query';
 import { GetServerSideProps, GetServerSidePropsContext } from 'next';
 import Image from 'next/image';
@@ -30,6 +31,7 @@ const BookRecordPage = () => {
   const router = useRouter();
   const registerImage = useMutation(registerImageApi);
   const registerBookRecord = useMutation(registerBookRecordApi);
+  const queryClient = useQueryClient();
   const { data: getBookDataByIsbn } = useQuery<getBookDataByIsbnProps>(
     ['getBookDataByIsbn', 'record'],
     () => getBookDataByIsbnApi(router.query.isbn as string),
@@ -113,6 +115,7 @@ const BookRecordPage = () => {
     registerBookRecord.mutate(data, {
       onSuccess: () => {
         alert('독서 기록 성공');
+        queryClient.invalidateQueries(['feed']);
         router.push('/');
       },
       onError: (error) => {


### PR DESCRIPTION
## 📌 이슈 번호

- close #355  <!-- 링크 달기 -->

## 👩‍💻 작업 내용

<!-- 자세히 쓰기 - 이미지가 필요한 경우 첨부하기, 영상도 ok -->
메인페이지 기록 피드 페이지에서 특정 피드 클릭한 후 다시 리스트로 돌아왔을 때 이전 스크롤 위치 기억하도록 하였습니다.
- 다른 곳에서도 쓰일 것 같아서 훅으로 구현하였어요!
- 새로고침 시에도 스크롤 위치를 저장할 수 있도록 로컬스토리지로 구현하였습니다.
- 메인 피드 api에 staleTime을 5분으로 지정하여 기록을 보고 돌아왔을 때 api 호출을 줄일 수 있도록 하였어요! 그래서 기록 작성 후에 해당 쿼리를 초기화하는 것을 추가하였습니다.
  - 만약 기록 작성 후 초기화가 필요한 쿼리가 있다면 쿼리키 `feed` 를 추가하면 될 것 같습니다!


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

<!-- 참고할 사항이 있다면 적어주세요 -->
