### PR TITLE
feat: 온보딩 리다이렉션 재적용

### DIFF
--- a/src/components/common/BottomNav.tsx
+++ b/src/components/common/BottomNav.tsx
@@ -1,28 +1,28 @@
 import Image from 'next/image';
 import { useRouter } from 'next/router';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 import tw from 'tailwind-styled-components';
 
 import { useAuth } from '@/hooks/useAuth';
 import { isAuthorizedSelector } from '@/recoil/auth';
+import { isRendedOnboardingAtom } from '@/recoil/onboarding';
 
 interface ButtonType {
   src: string;
   text: string;
   path: string;
-  as?: string;
 }
 
 const BottomNav = () => {
   const { openAuthRequiredModal } = useAuth();
   const isAuthorized = useRecoilValue(isAuthorizedSelector);
+  const setIsRendedOnboarding = useSetRecoilState(isRendedOnboardingAtom);
 
   const { push, pathname } = useRouter();
 
   const navItemPropertyArr: ButtonType[] = [
     {
-      path: '/?isRendedOnboarding=true',
-      as: '/',
+      path: '/',
       text: '홈',
       src: 'home',
     },
@@ -48,21 +48,21 @@ const BottomNav = () => {
     },
   ];
 
-  const moveBottomNavPage = (path: string, src: string, as?: string) => {
+  const moveBottomNavPage = (path: string, src: string) => {
     if (src === 'record' && !isAuthorized) return openAuthRequiredModal();
-    push(path, as && as);
+    if (src === 'home') setIsRendedOnboarding(true);
+    push(path);
   };
 
   return (
     <Container>
       <Wrap>
         {navItemPropertyArr.map((button: ButtonType) => {
-          const { path, text, src, as } = button;
-          const isClickedPath = src === 'home' ? '/' : path;
-          const isClicked = isClickedPath === pathname;
+          const { path, text, src } = button;
+          const isClicked = path === pathname;
 
           return (
-            <Button onClick={() => moveBottomNavPage(path, src, as)} key={src}>
+            <Button onClick={() => moveBottomNavPage(path, src)} key={src}>
               <Image
                 width={45}
                 height={45}

--- a/src/components/recommend/RecommendResultModal.tsx
+++ b/src/components/recommend/RecommendResultModal.tsx
@@ -10,6 +10,7 @@ import tw from 'tailwind-styled-components';
 import { postBookshelfApi } from '@/api/bookshelf';
 import { isAuthorizedSelector } from '@/recoil/auth';
 import { selectRecommendResultModalAtom } from '@/recoil/modal';
+import { isRendedOnboardingAtom } from '@/recoil/onboarding';
 
 interface RecommendResultType {
   authors: string[];
@@ -46,6 +47,7 @@ const ModalOverlay = ({
   const isAuthorized = useRecoilValue(isAuthorizedSelector);
   const router = useRouter();
   const [flip, setFlip] = useState(false);
+  const setIsRendedOnboarding = useSetRecoilState(isRendedOnboardingAtom);
 
   const handleAddMyBookShelf = () => {
     const bookData = {
@@ -75,15 +77,8 @@ const ModalOverlay = ({
   };
 
   const handleMoveMain = () => {
-    router.push(
-      {
-        pathname: '/',
-        query: {
-          isRendedOnboarding: 'true',
-        },
-      },
-      '/',
-    );
+    router.push('/');
+    setIsRendedOnboarding(true);
     setRecommendResultModal(false);
   };
 

--- a/src/layout/ProfileLayout.tsx
+++ b/src/layout/ProfileLayout.tsx
@@ -8,6 +8,7 @@ import { useSetRecoilState } from 'recoil';
 import { logout } from '@/api/auth';
 import { getProfileApi } from '@/api/profile';
 import { isAuthorizedSelector } from '@/recoil/auth';
+import { isRendedOnboardingAtom } from '@/recoil/onboarding';
 
 function ProfileLayout({ children }: { children: ReactNode }) {
   const {
@@ -15,6 +16,7 @@ function ProfileLayout({ children }: { children: ReactNode }) {
     push,
     pathname,
   } = useRouter();
+  const setIsRendedOnboarding = useSetRecoilState(isRendedOnboardingAtom);
   const mine = !ownerId;
   const { data: someoneData, status: someoneStatus } = useQuery(
     ['getUserProfile', 'profile', ownerId],
@@ -34,8 +36,8 @@ function ProfileLayout({ children }: { children: ReactNode }) {
 
   const onLogout = () => {
     logout();
-    push('/');
     setIsAuthorized(false);
+    setIsRendedOnboarding(true);
   };
 
   const routes = (pathname: string) => {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,7 +2,8 @@ import { dehydrate, QueryClient, useQuery } from '@tanstack/react-query';
 import { GetServerSideProps } from 'next';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
-import { useRecoilValue } from 'recoil';
+import { useEffect } from 'react';
+import { useRecoilState, useRecoilValue } from 'recoil';
 
 import { getRecommendBookShelf } from '@/api/bookshelf';
 import { fetchBestGroup } from '@/api/main';
@@ -12,6 +13,7 @@ import BestRecruitList from '@/components/main/bestRecruit/BestRecruitList';
 import RecordFeedList from '@/components/main/mainRecordFeed/RecordFeedList';
 import { useAuth } from '@/hooks/useAuth';
 import { isAuthorizedSelector } from '@/recoil/auth';
+import { isRendedOnboardingAtom } from '@/recoil/onboarding';
 import { BestGroupListType } from '@/types/recruit';
 
 interface MainSSRProps {
@@ -30,10 +32,15 @@ export default function Home({ bestGroup }: MainSSRProps) {
     getRecommendBookShelf(isAuthorized),
   );
 
-  const {
-    query: { isRendedOnboarding },
-    push,
-  } = useRouter();
+  const { push } = useRouter();
+
+  const [isRendedOnboarding, setIsRendedOnboarding] = useRecoilState(
+    isRendedOnboardingAtom,
+  );
+
+  useEffect(() => {
+    moveOnboardingPage();
+  }, []);
 
   const handleMoveRecommendPage = () => {
     if (!isAuthorized) return openAuthRequiredModal();
@@ -41,10 +48,14 @@ export default function Home({ bestGroup }: MainSSRProps) {
     push('/recommend');
   };
 
-  if (!isAuthorized && !isRendedOnboarding) {
-    push('/onboarding');
-    return <></>;
-  }
+  const moveOnboardingPage = () => {
+    if (!isAuthorized && !isRendedOnboarding) {
+      push('/onboarding');
+      return <></>;
+    }
+
+    setIsRendedOnboarding(false);
+  };
 
   if (isBookshelfError) return <></>;
 

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -1,20 +1,26 @@
 import Image from 'next/image';
-import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 import tw from 'tailwind-styled-components';
 
 import LoginButton from '@/components/auth/LoginButton';
 import { isAuthorizedSelector } from '@/recoil/auth';
+import { isRendedOnboardingAtom } from '@/recoil/onboarding';
 
 const LoginPage = () => {
-  const { back } = useRouter();
+  const { back, push } = useRouter();
   const isAuthorized = useRecoilValue(isAuthorizedSelector);
+  const setIsRendedOnboarding = useSetRecoilState(isRendedOnboardingAtom);
 
   useEffect(() => {
     if (isAuthorized) back();
   }, [isAuthorized, back]);
+
+  const moveMainPage = () => {
+    push('/');
+    setIsRendedOnboarding(true);
+  };
 
   return (
     !isAuthorized && (
@@ -45,7 +51,7 @@ const LoginPage = () => {
               </ButtonItem>
               <ButtonItem></ButtonItem>
             </LoginButton>
-            <LinkStyles href='/'>일단 둘러보기</LinkStyles>
+            <LinkStyles onClick={moveMainPage}>일단 둘러보기</LinkStyles>
           </UserSelectWrapper>
         </Wrap>
       </Container>
@@ -87,7 +93,7 @@ const ButtonItem = tw.div`
   w-[25%]
 `;
 
-const LinkStyles = tw(Link)`
+const LinkStyles = tw.button`
   text-sm	
   text-[#707070]
   border-b	

--- a/src/pages/onboarding/index.tsx
+++ b/src/pages/onboarding/index.tsx
@@ -2,6 +2,9 @@ import Image from 'next/image';
 import { useRouter } from 'next/router';
 import React, { Fragment, useState } from 'react';
 import Slider from 'react-slick';
+import { useSetRecoilState } from 'recoil';
+
+import { isRendedOnboardingAtom } from '@/recoil/onboarding';
 
 const ONBOADINGDATA = [
   {
@@ -38,6 +41,7 @@ const ONBOADINGDATA = [
 
 const OnboardingPage = () => {
   const [lastSlide, setLastSlide] = useState(false);
+  const setIsRendedOnboarding = useSetRecoilState(isRendedOnboardingAtom);
   const router = useRouter();
 
   const settings = {
@@ -54,15 +58,8 @@ const OnboardingPage = () => {
   };
 
   const handleMoveMain = () => {
-    router.push(
-      {
-        pathname: '/',
-        query: {
-          isRendedOnboarding: 'true',
-        },
-      },
-      '/',
-    );
+    router.push('/');
+    setIsRendedOnboarding(true);
   };
 
   const handleMoveRecommend = () => {

--- a/src/recoil/onboarding.ts
+++ b/src/recoil/onboarding.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const isRendedOnboardingAtom = atom({
+  key: 'isRendedOnboarding',
+  default: false,
+});


### PR DESCRIPTION
## 📌 이슈 번호

- close #362  <!-- 링크 달기 -->

## 👩‍💻 작업 내용

<!-- 자세히 쓰기 - 이미지가 필요한 경우 첨부하기, 영상도 ok -->
- 비로그인 시 최초 접속 제외하고 온보딩으로 가지 않도록 처리하였습니다.
(로그인 페이지 둘러보기 버튼, 로그아웃 시 .... etc)

- 기존에 query로 처리하고 있었는데 로그아웃시 atom 값이 업데이트되면서 구독하고 있는 컴포넌트가 업데이트되어 바로 온보딩 페이지로 이동되면서 router 처리가 적용되지 않고 있었습니다. 따라서 로그아웃시 query값을 전달할 수 없을 것 같아 recoil 을 사용하는 방법으로 변경하였습니다~

- 리팩토링 
  - 최초 접속을 제외하고 온보딩을 가지 않기 때문에 페이지 마다 recoil값을 변경하지 않고 로그아웃할 때만 변경하면 되지 않을까? 했는데 로그아웃 시에도 메인으로 가야해서 처리하기가 애매하여 일단 페이지마다 리코일값 변경하도록 하였습니다. 추후 아이디어가 떠오르면 리팩토링 예정입니다!
  - 현재 온보딩으로 리다이렉션될 때 깜빡임 현상이 있는데 이는 추후 리팩토링 할 때 수정할 예정입니다~


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

<!-- 참고할 사항이 있다면 적어주세요 -->
