### PR TITLE
fix: 도서 검색 페이지, 도서 선택 페이지 검색 탭 기록이 공유되는 현상 해결

### DIFF
--- a/src/components/book/search/InfinityScrollLists.tsx
+++ b/src/components/book/search/InfinityScrollLists.tsx
@@ -1,15 +1,11 @@
 import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query';
-import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 import { useInView } from 'react-intersection-observer';
-import { useRecoilState, useSetRecoilState } from 'recoil';
+import { useRecoilState } from 'recoil';
 import tw from 'tailwind-styled-components';
 
 import { getBookSearchResultData } from '@/api/book';
-import {
-  searchBookTitleAtom,
-  searchInfinityScrollPageAtom,
-} from '@/recoil/book';
+import { searchInfinityScrollPageAtom } from '@/recoil/book';
 
 import SearchResultList from './SearchResultList';
 
@@ -20,8 +16,6 @@ interface InfinityScrollListsProps {
 const InfinityScrollLists = ({ searchKeyword }: InfinityScrollListsProps) => {
   const { ref, inView } = useInView();
   const [page, setPage] = useRecoilState(searchInfinityScrollPageAtom);
-  const setSearchKeyword = useSetRecoilState(searchBookTitleAtom);
-  const { pathname } = useRouter();
   const queryClient = useQueryClient();
   const isBookSearchData = !!queryClient.getQueryData([
     'book',
@@ -51,12 +45,6 @@ const InfinityScrollLists = ({ searchKeyword }: InfinityScrollListsProps) => {
       enabled: !!searchKeyword && !isBookSearchData,
     },
   );
-
-  useEffect(() => {
-    if (pathname === '/book/record/search') {
-      setSearchKeyword('');
-    }
-  }, [pathname, setSearchKeyword]);
 
   useEffect(() => {
     if (inView && bookSearchResultLists) {

--- a/src/components/book/search/InfinityScrollLists.tsx
+++ b/src/components/book/search/InfinityScrollLists.tsx
@@ -2,11 +2,14 @@ import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 import { useInView } from 'react-intersection-observer';
-import { useRecoilState } from 'recoil';
+import { useRecoilState, useSetRecoilState } from 'recoil';
 import tw from 'tailwind-styled-components';
 
 import { getBookSearchResultData } from '@/api/book';
-import { searchInfinityScrollPageAtom } from '@/recoil/book';
+import {
+  searchBookTitleAtom,
+  searchInfinityScrollPageAtom,
+} from '@/recoil/book';
 
 import SearchResultList from './SearchResultList';
 
@@ -17,6 +20,7 @@ interface InfinityScrollListsProps {
 const InfinityScrollLists = ({ searchKeyword }: InfinityScrollListsProps) => {
   const { ref, inView } = useInView();
   const [page, setPage] = useRecoilState(searchInfinityScrollPageAtom);
+  const setSearchKeyword = useSetRecoilState(searchBookTitleAtom);
   const { pathname } = useRouter();
   const queryClient = useQueryClient();
   const isBookSearchData = !!queryClient.getQueryData([
@@ -34,7 +38,7 @@ const InfinityScrollLists = ({ searchKeyword }: InfinityScrollListsProps) => {
     isFetchingNextPage,
     status,
   } = useInfiniteQuery(
-    ['book', 'search', 'result', 'list', searchKeyword, pathname],
+    ['book', 'search', 'result', 'list', searchKeyword],
     ({ pageParam = 1 }) => getBookSearchResultData(searchKeyword, pageParam),
     {
       onSuccess: () => setPage((prev) => prev + 1),
@@ -47,6 +51,12 @@ const InfinityScrollLists = ({ searchKeyword }: InfinityScrollListsProps) => {
       enabled: !!searchKeyword && !isBookSearchData,
     },
   );
+
+  useEffect(() => {
+    if (pathname === '/book/record/search') {
+      setSearchKeyword('');
+    }
+  }, [pathname, setSearchKeyword]);
 
   useEffect(() => {
     if (inView && bookSearchResultLists) {

--- a/src/pages/book/record/search.tsx
+++ b/src/pages/book/record/search.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { ReactElement } from 'react';
 import { useRecoilState, useRecoilValue } from 'recoil';
 
@@ -18,6 +18,10 @@ const BookRecordSearchPage: NextPageWithLayout = () => {
   const onSubmit = (keyword: string) => {
     setSearchBookTitle(keyword);
   };
+
+  useEffect(() => {
+    setSearchBookTitle('');
+  }, [setSearchBookTitle]);
 
   return (
     <>


### PR DESCRIPTION
## 📌 이슈 번호

- close #383 

## 👩‍💻 작업 내용

-도서 검색 페이지, 도서 선택 페이지 검색 탭 기록이 공유되는 현상 해결

<!-- 자세히 쓰기 - 이미지가 필요한 경우 첨부하기, 영상도 ok -->

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
- 도서 선택 페이지의 도서 검색 탭을 누르면 도서 제목을 초기화되게 하였습니다. 이렇게 하면 검색탭을 누를 때마다 초기화가 되어 책장 탭, 검색 탭 이동할 때마다 초기화가 되고, 검색 탭으로 이동했다가 네비게이션을 이용하여 도서 검색 페이지로 가도 데이터가 초기화가 되게 됩니다. 일단 이렇게 구현했는데 리팩토링 때 좀 더 효율적인 방법이 있나 고민해보고 적용해야할 것 같습니다.
<!-- 참고할 사항이 있다면 적어주세요 -->
