### PR TITLE
fix: 메인 피드 데스크탑 모드 시 이미지 안보임 해결

### DIFF
--- a/src/components/main/mainRecordFeed/FeedItem.tsx
+++ b/src/components/main/mainRecordFeed/FeedItem.tsx
@@ -55,12 +55,14 @@ const FeedItem = ({ text, book, user, recordId }: RecordType) => {
         backgroundColor: `${bookCoverBgColor}20`,
       }}
     >
-      <div className='py-4 '>
+      <div className='py-4'>
         <h3 className='h-6 text-clampBase font-bold truncate max-w-[50vw]'>
           #{title}
         </h3>
         <p className='text-xs pb-3 pt-2 truncate w-[45vw] max-w-sm'>{text}</p>
-        <p className='text-xs text-[#707070] truncate w-[45vw]'>@{nickname}</p>
+        <p className='text-xs text-[#707070] truncate w-[45vw] max-w-sm'>
+          @{nickname}
+        </p>
       </div>
       <div className='flex-none mt-4 xxs:mt-5'>
         <Image


### PR DESCRIPTION
## 📌 이슈 번호

- close #407 <!-- 링크 달기 -->

## 👩‍💻 작업 내용

<!-- 자세히 쓰기 - 이미지가 필요한 경우 첨부하기, 영상도 ok -->
- 메인페이지 피드에서 데스크탑 모드일 시 이미지가 안보이는 현상을 해결하였습니다.


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

<!-- 참고할 사항이 있다면 적어주세요 -->
