### PR TITLE
fix: 모집여부 변경 모달 낙관적 업데이트 적용

### DIFF
--- a/src/components/recruit/detail/RecruitStatusSelectModal.tsx
+++ b/src/components/recruit/detail/RecruitStatusSelectModal.tsx
@@ -5,6 +5,7 @@ import { useSetRecoilState } from 'recoil';
 
 import { patchReadingClassChange } from '@/api/recruit';
 import { selectRecruitStatusAtom } from '@/recoil/modal';
+import { GroupList } from '@/types/recruit';
 
 interface RecruitmentModalType {
   groupId: number;
@@ -28,8 +29,29 @@ const ModalOverlay = ({ groupId, recruitmentStatus }: RecruitmentModalType) => {
   const { mutate: updateRecruitmentStatus } = useMutation(
     patchReadingClassChange,
     {
-      onSuccess: () => {
+      onMutate: async ({ groupData }) => {
+        const oldData: GroupList | undefined = queryClient.getQueryData([
+          'recruitDetail',
+          String(groupId),
+        ]);
+
+        await queryClient.cancelQueries(['recruitDetail', String(groupId)]);
+
+        if ('recruitment_status' in groupData) {
+          queryClient.setQueryData(['recruitDetail', String(groupId)], {
+            ...oldData,
+            recruitment_status: groupData.recruitment_status,
+          });
+        }
+
         setModal(false);
+        return () =>
+          queryClient.setQueryData(['recruitDetail', String(groupId)], oldData);
+      },
+      onError: (error, variable, rollback) => {
+        if (rollback) return rollback();
+      },
+      onSuccess: () => {
         return queryClient.invalidateQueries([
           'recruitDetail',
           String(groupId),
@@ -86,7 +108,7 @@ const ModalOverlay = ({ groupId, recruitmentStatus }: RecruitmentModalType) => {
   return (
     <>
       <div className='fixed left-0 right-0 w-5/6 max-w-lg bg-[#F3F3F3] h-40 z-30 rounded-2xl bottom-24 animate-slideUp mx-auto'>
-        <div className='flex flex-col justify-center items-center divide-y'>
+        <div className='flex flex-col items-center justify-center divide-y'>
           <p className='h-11 flex justify-center items-center text-[#707070] text-clamSm'>
             상태 변경
           </p>
@@ -95,7 +117,7 @@ const ModalOverlay = ({ groupId, recruitmentStatus }: RecruitmentModalType) => {
       </div>
       <button
         onClick={() => setModal(false)}
-        className='fixed left-0 right-0 w-5/6 max-w-lg bg-white h-14 z-30 rounded-2xl bottom-8 mx-auto text-clampLg text-main animate-slideUp'
+        className='fixed left-0 right-0 z-30 w-5/6 max-w-lg mx-auto bg-white h-14 rounded-2xl bottom-8 text-clampLg text-main animate-slideUp'
       >
         닫기
       </button>

--- a/src/components/recruit/detail/RecruitStatusSelectModal.tsx
+++ b/src/components/recruit/detail/RecruitStatusSelectModal.tsx
@@ -51,12 +51,6 @@ const ModalOverlay = ({ groupId, recruitmentStatus }: RecruitmentModalType) => {
       onError: (error, variable, rollback) => {
         if (rollback) return rollback();
       },
-      onSuccess: () => {
-        return queryClient.invalidateQueries([
-          'recruitDetail',
-          String(groupId),
-        ]);
-      },
     },
   );
 


### PR DESCRIPTION
## 📌 이슈 번호

- close #424 <!-- 링크 달기 -->

## 👩‍💻 작업 내용

<!-- 자세히 쓰기 - 이미지가 필요한 경우 첨부하기, 영상도 ok -->
모집여부 변경에서 로딩이 걸렸을 때 버튼을 여러 번 클릭하는 걸 막는 방법으로 버튼 클릭 시 바로 모달을 닫고 ui를 업데이트하는 낙관적 업데이트를 적용하였습니다.

- 느린 3G로 테스트한 화면입니다. (네트워크 대기중임에도 ui는 낙관적 업데이트 진행)
![독서모임 낙관적 업데이트 적용 후 네트워크까지 보이도록](https://github.com/dugeun-dugeun-project/frontend/assets/107309247/bd2d7c81-72d6-4872-8807-82cf8373c2e0)


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

<!-- 참고할 사항이 있다면 적어주세요 -->
