### PR TITLE
fix: 뒤로가기 시 스크롤 하단으로 움직임 수정

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -57,6 +57,12 @@ export default function App({ Component, pageProps }: AppPropsWithLayout) {
     setHydrated(true);
   }, []);
 
+  useEffect(() => {
+    if ('scrollRestoration' in window.history) {
+      window.history.scrollRestoration = 'manual';
+    }
+  }, []);
+
   if (!hydrated) return null;
 
   const getLayout =


### PR DESCRIPTION
## 📌 이슈 번호

- close #429  <!-- 링크 달기 -->

## 👩‍💻 작업 내용

<!-- 자세히 쓰기 - 이미지가 필요한 경우 첨부하기, 영상도 ok -->
메인에서만 발생하는 현상인 줄 알았는데 **스크롤이 되는 모든 페이지에서는 아래 gif와 같이 뒤로가기를 누르면 스크롤이 하단으로 내려갔다가 페이지 이동되는 모습**이 보였습니다.
<img src='https://github.com/dugeun-dugeun-project/frontend/assets/107309247/17da180b-d5c2-4012-9bb5-8e4985c65bdb' width=400/>
<br/>
해당 현상은 브라우저에서 이전 브라우저의 스크롤 위치를 자동으로 복원하려고 하는 기본 동작으로 인해 발생하는 것 같습니다! 해당 기능을 조절하였더니 아래와 같이 해당 버그 없이 잘 동작합니다!

<img src='https://github.com/dugeun-dugeun-project/frontend/assets/107309247/11761eee-fb06-41a1-b8f3-fea9bb7993f6' width=400/>

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

<!-- 참고할 사항이 있다면 적어주세요 -->
